### PR TITLE
Add lookaround support in regex builder

### DIFF
--- a/core/regex/regex_builder.py
+++ b/core/regex/regex_builder.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Literal
+from typing import List, Literal, Optional
 from .enum_generator import EnumRegexGenerator
 from .generalizer import generalize_token
 from core.tokenizer.tree_tokenizer import build_token_tree, flatten_token_tree
@@ -8,10 +8,14 @@ KEY_VALUE_SEPARATORS = {'=', ':', '->', '=>', '<-'}
 
 DigitMode = Literal["standard", "always_fixed_length", "always_plus", "min_length", "fixed_and_min"]
 
-def build_draft_regex_from_examples(lines: List[str], *,
-                                     digit_mode: DigitMode = "standard",
-                                     digit_min_length: int = 1,
-                                     case_insensitive: bool = False) -> str:
+def build_draft_regex_from_examples(
+        lines: List[str], *,
+        digit_mode: DigitMode = "standard",
+        digit_min_length: int = 1,
+        case_insensitive: bool = False,
+        window_left: Optional[str] = None,
+        window_right: Optional[str] = None,
+) -> str:
     token_columns = []
     sep_columns = []
 
@@ -111,4 +115,12 @@ def build_draft_regex_from_examples(lines: List[str], *,
 
         i += 1
 
-    return ''.join(token_patterns)
+    core_pattern = ''.join(token_patterns)
+
+    if window_left:
+        core_pattern = f"(?<={re.escape(window_left)}){core_pattern}"
+    if window_right:
+        core_pattern = f"{core_pattern}(?={re.escape(window_right)})"
+
+    core_pattern = core_pattern.strip()
+    return core_pattern

--- a/tests/test_regex_builder.py
+++ b/tests/test_regex_builder.py
@@ -1,4 +1,10 @@
 import re
+import os
+import sys
+
+# Ensure the core package is importable when running tests directly
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from core.regex.regex_builder import build_draft_regex_from_examples
 
 
@@ -43,3 +49,15 @@ def test_regex_modes_case_insensitive():
     assert re.fullmatch(regex, "type=ERROR")
     assert re.fullmatch(regex, "type=info")
     assert not re.fullmatch(regex, "type=warn")
+
+
+def test_regex_window_lookaround():
+    logs = ['val=1', 'val=22']
+    regex = build_draft_regex_from_examples(
+        logs,
+        window_left='start ',
+        window_right=' end'
+    )
+    assert regex.startswith('(?<=') and '(?=' in regex
+    match = re.search(regex, 'prefix start val=1 end suffix')
+    assert match

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,5 +1,5 @@
 import pytest
-from core.tokenizer.tree_tokenizer import build_token_tree  # путь может отличаться в зависимости от структуры проекта
+from core.tokenizer.tree_tokenizer import build_token_tree, flatten_token_tree
 
 @pytest.mark.parametrize("input_str, expected", [
     ("abc def", [("abc", "token"), (" ", "sep"), ("def", "token")]),
@@ -15,5 +15,6 @@ from core.tokenizer.tree_tokenizer import build_token_tree  # путь може�
     ("a_b-c", [("a", "token"), ("_", "sep"), ("b", "token"), ("-", "sep"), ("c", "token")]),
 ])
 def test_tokenize(input_str, expected):
-    result = build_token_tree(input_str)
+    tree = build_token_tree(input_str)
+    result = flatten_token_tree(tree)
     assert result == expected, f"Failed for input: {input_str}"


### PR DESCRIPTION
## Summary
- extend `build_draft_regex_from_examples` with optional window_left/window_right
- update tokenizer tests to use flattened token trees
- add lookaround regression test for regex builder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa08dacd0832b9ba58436012e9f96