### PR TITLE
Change coverage metric to use significant characters

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -11,6 +11,7 @@ from gui.pattern_panel import PatternPanel
 from utils.color_utils import generate_distinct_colors
 from gui.tooltip import ToolTip
 from gui.pattern_wizard import PatternWizardDialog
+from utils.text_utils import compute_char_coverage
 import re
 import os
 
@@ -107,11 +108,7 @@ class AppWindow(tk.Frame):
     def _compute_coverage(self, active_names) -> float:
         if not self.logs:
             return 0.0
-        matched_lines = 0
-        for matches in self.match_cache.values():
-            if any(m["name"] in active_names for m in matches):
-                matched_lines += 1
-        return matched_lines / len(self.logs) * 100
+        return compute_char_coverage(self.logs, self.match_cache, active_names)
 
     def render_page(self):
         self.text_area.delete(1.0, tk.END)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from typing import List, Dict
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils.text_utils import compute_char_coverage
+
+
+def test_compute_char_coverage():
+    logs = [
+        "error 123",
+        "abc 456",
+        "def"
+    ]
+    match_cache: Dict[int, List[Dict]] = {
+        1: [
+            {"name": "p1", "match": "error 123"}
+        ],
+        2: [
+            {"name": "p2", "match": "abc"}
+        ],
+        3: []
+    }
+    active_names = {"p1", "p2"}
+    coverage = compute_char_coverage(logs, match_cache, active_names)
+    assert round(coverage, 1) == round(11 / 17 * 100, 1)

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -1,4 +1,6 @@
 import os
+import re
+from typing import List, Dict
 
 
 def common_prefix(words):
@@ -29,3 +31,38 @@ def common_suffix(words):
         if not suffix:
             break
     return suffix
+
+
+def count_significant_chars(text: str) -> int:
+    """Return the length of text excluding any whitespace characters."""
+    return len("".join(ch for ch in text if not ch.isspace()))
+
+
+def compute_char_coverage(
+    logs: List[str], matches_by_line: Dict[int, List[Dict]], active_names: set
+) -> float:
+    """Calculate coverage by number of significant characters.
+
+    Parameters
+    ----------
+    logs : List[str]
+        Source log lines.
+    matches_by_line : Dict[int, List[Dict]]
+        Mapping of line number to list of match dictionaries.
+    active_names : set
+        Names of patterns that should be counted in coverage.
+
+    Returns
+    -------
+    float
+        Coverage percentage from 0 to 100.
+    """
+    total = sum(count_significant_chars(line) for line in logs)
+    if total == 0:
+        return 0.0
+    covered = 0
+    for lineno, matches in matches_by_line.items():
+        for m in matches:
+            if m.get("name") in active_names:
+                covered += count_significant_chars(m.get("match", ""))
+    return covered / total * 100


### PR DESCRIPTION
## Summary
- support calculating the number of significant characters
- expose `compute_char_coverage` and use it in the GUI
- test new character-based coverage metric

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd070b02c832bbf502cd2725f8526