### PR TITLE
Add tooltips for CEF fields

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -2,7 +2,7 @@ import tkinter as tk
 from tkinter import filedialog, ttk, messagebox, simpledialog
 from utils.json_utils import (
     load_all_patterns,
-    load_cef_field_keys,
+    load_cef_fields,
     get_log_name_for_file,
     save_per_log_pattern,
 )
@@ -26,7 +26,7 @@ class AppWindow(tk.Frame):
         self.tooltip = ToolTip(self)
         self.pattern_panel = None
         self.match_cache = {}  # lineno -> list of matches
-        self.cef_fields = load_cef_field_keys()
+        self.cef_fields = load_cef_fields()
 
         self._setup_widgets()
         self._load_patterns()

--- a/gui/pattern_wizard.py
+++ b/gui/pattern_wizard.py
@@ -437,13 +437,19 @@ class PatternWizardDialog(tk.Toplevel):
         for widget in self.cef_field_inner.winfo_children():
             widget.destroy()
         for field in self.cef_fields:
-            if query in field.lower():
-                var = self.selected_field_vars.get(field)
+            key = field.get("key", "")
+            name = field.get("name", "")
+            example = field.get("example", "")
+            if query in (key + name).lower():
+                var = self.selected_field_vars.get(key)
                 if not var:
                     var = tk.BooleanVar()
-                    self.selected_field_vars[field] = var
-                ttk.Checkbutton(
+                    self.selected_field_vars[key] = var
+                chk = ttk.Checkbutton(
                     self.cef_field_inner,
-                    text=field,
+                    text=key,
                     variable=var
-                ).pack(anchor="w")
+                )
+                chk.pack(anchor="w")
+                tip = f"{name}\nПример: {example}"
+                self._add_tip(chk, tip)

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -115,12 +115,16 @@ def save_per_log_pattern(source_file, pattern_name, pattern_data, log_name=None)
         print(f"[Ошибка сохранения пер-лог паттерна] {e}")
 
 
-def load_cef_field_keys():
-    """Возвращает список ключей полей CEF из data/cef_fields.json."""
+def load_cef_fields():
+    """Возвращает список словарей с описанием CEF-полей."""
     try:
         with open(CEF_FIELDS_PATH, "r", encoding="utf-8") as f:
             data = json.load(f)
-            fields = data.get("fields", [])
-            return [fld.get("key") for fld in fields if "key" in fld]
+            return data.get("fields", [])
     except (FileNotFoundError, json.JSONDecodeError):
         return []
+
+
+def load_cef_field_keys():
+    """Возвращает список ключей CEF-полей."""
+    return [fld.get("key") for fld in load_cef_fields() if "key" in fld]


### PR DESCRIPTION
## Summary
- load full CEF field info from `cef_fields.json`
- pass detailed CEF field info to Pattern Wizard
- show tooltips for every CEF field checkbox with its name and example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe5a36aa0832b87c3321c0465d07f