### PR TITLE
Handle log-specific regex matches

### DIFF
--- a/tests/test_regex_highlighter.py
+++ b/tests/test_regex_highlighter.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from core.regex_highlighter import compute_optimal_matches
+
+
+def test_log_specific_overrides_builtin():
+    line = "foobar"
+    patterns = [
+        {"regex": "foo", "source": "builtin", "name": "b"},
+        {"regex": "foobar", "source": "log", "name": "l"},
+    ]
+    matches = compute_optimal_matches(line, patterns)
+    assert len(matches) == 1
+    assert matches[0]["match"] == "foobar"
+    assert matches[0]["source"] == "log"


### PR DESCRIPTION
## Summary
- keep log-specific matches separately in `compute_optimal_matches`
- ignore built-in/user matches that intersect log-specific ones
- document three pattern classes
- test that log-specific matches override built-in matches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684045457930832b881f5f28f310f73b