### PR TITLE
Replace prints with logging

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -12,8 +12,11 @@ from utils.color_utils import generate_distinct_colors
 from gui.tooltip import ToolTip
 from gui.pattern_wizard import PatternWizardDialog
 from utils.text_utils import compute_char_coverage
+import logging
 import re
 import os
+
+logger = logging.getLogger(__name__)
 
 
 class AppWindow(tk.Frame):
@@ -168,9 +171,15 @@ class AppWindow(tk.Frame):
 
         for line_num, matches in matches_to_show.items():
             if has_overlap(matches):
-                print(f"[WARNING] Overlapping patterns on line {line_num}:")
+                logger.warning("Overlapping patterns on line %s:", line_num)
                 for m in matches:
-                    print(f"  - {m['start']}..{m['end']} → {m['name']} ({m['regex']})")
+                    logger.warning(
+                        "  - %s..%s → %s (%s)",
+                        m['start'],
+                        m['end'],
+                        m['name'],
+                        m['regex'],
+                    )
 
         # Подсветка текста
         apply_highlighting(self.text_area, matches_to_show, active_names, color_map)
@@ -257,7 +266,7 @@ class AppWindow(tk.Frame):
             self._cache_matches()
             self.render_page()
         except Exception as e:
-            print(f"[Ошибка PatternWizard] {e}")
+            logger.error("[PatternWizard] %s", e)
             messagebox.showerror("Ошибка", f"Не удалось открыть мастер: {e}")
 
     def get_selected_lines(self):

--- a/gui/pattern_wizard.py
+++ b/gui/pattern_wizard.py
@@ -1,6 +1,9 @@
+import logging
 import tkinter as tk
 from tkinter import ttk, messagebox
 import re
+
+logger = logging.getLogger(__name__)
 
 from core.regex_highlighter import apply_highlighting
 from gui.tooltip import ToolTip
@@ -233,7 +236,7 @@ class PatternWizardDialog(tk.Toplevel):
 
     def _generate_regex(self):
         try:
-            print("[Wizard] Генерация регулярного выражения...")
+            logger.info("[Wizard] Генерация регулярного выражения...")
 
             # Поддержка генерации даже при одной строке
             lines = self.selected_lines
@@ -252,7 +255,7 @@ class PatternWizardDialog(tk.Toplevel):
                 prefer_alternatives=self.prefer_alternatives_var.get(),
                 merge_by_common_prefix=self.merge_by_prefix_var.get(),
             )
-            print("[Wizard] Получено:", draft)
+            logger.info("[Wizard] Получено: %s", draft)
 
             self._push_history(draft)
             self.regex_var.set(draft)
@@ -261,7 +264,7 @@ class PatternWizardDialog(tk.Toplevel):
             self._apply_regex()
 
         except Exception as e:
-            print(f"[Wizard Error] {e}")
+            logger.error("[Wizard Error] %s", e)
             messagebox.showerror("Ошибка генерации", str(e))
 
     def _apply_regex(self):

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -1,5 +1,8 @@
 import json
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 # Папка для пользовательских файлов
 USER_DATA_DIR = os.path.join("data", "user")
@@ -37,7 +40,7 @@ def save_user_patterns(patterns):
         with open(USER_PATTERNS_PATH, "w", encoding="utf-8") as f:
             json.dump(to_save, f, indent=4, ensure_ascii=False)
     except IOError as e:
-        print(f"[Ошибка сохранения] {e}")
+        logger.error("[Ошибка сохранения] %s", e)
 
 def save_user_pattern(new_pattern):
     patterns = load_all_patterns()
@@ -112,7 +115,7 @@ def save_per_log_pattern(source_file, pattern_name, pattern_data, log_name=None)
         with open(PER_LOG_PATTERNS_PATH, "w", encoding="utf-8") as f:
             json.dump(all_data, f, indent=4, ensure_ascii=False)
     except Exception as e:
-        print(f"[Ошибка сохранения пер-лог паттерна] {e}")
+        logger.error("[Ошибка сохранения пер-лог паттерна] %s", e)
 
 
 def load_cef_fields():


### PR DESCRIPTION
## Summary
- use the logging module in `gui.app_window`, `gui.pattern_wizard`, and
  `utils.json_utils`
- emit warnings and errors through `logger`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404d128f3c832ba1b7904656782125