### PR TITLE
Fix regex init exports

### DIFF
--- a/core/regex/__init__.py
+++ b/core/regex/__init__.py
@@ -1,3 +1,11 @@
+"""Public interface for regex helper utilities."""
+
 from .regex_builder import build_draft_regex_from_examples
 from .enum_generator import EnumRegexGenerator
 from .generalizer import generalize_token
+
+__all__ = [
+    "build_draft_regex_from_examples",
+    "EnumRegexGenerator",
+    "generalize_token",
+]


### PR DESCRIPTION
## Summary
- expand regex package exports

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_68404d0fbbdc832b83884095a731e856