### PR TITLE
Fix per-log pattern saving

### DIFF
--- a/tests/test_per_log_patterns.py
+++ b/tests/test_per_log_patterns.py
@@ -15,8 +15,8 @@ def test_load_per_log_patterns_for_file(tmp_path, monkeypatch):
         "log": {
             "file": "/var/log/app.log",
             "patterns": {
-                "A": {"regex": "foo"},
-                "B": {"regex": "bar"},
+                "A": {"regex": "foo", "category": "x", "priority": 1},
+                "B": {"regex": "bar", "source": "builtin"},
             },
         }
     }
@@ -26,7 +26,11 @@ def test_load_per_log_patterns_for_file(tmp_path, monkeypatch):
     patterns = json_utils.load_per_log_patterns_for_file("/var/log/app.log")
     names = {p["name"] for p in patterns}
     assert names == {"A", "B"}
-    assert all(p["source"] == "per_log" for p in patterns)
+    srcs = {p["source"] for p in patterns}
+    assert srcs == {"per_log", "builtin"}
+    cat = next(p for p in patterns if p["name"] == "A")
+    assert cat["category"] == "x"
+    assert cat["priority"] == 1
 
 
 def test_cache_matches_includes_per_log(monkeypatch):

--- a/tests/test_save_per_log_pattern.py
+++ b/tests/test_save_per_log_pattern.py
@@ -1,0 +1,41 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils import json_utils
+
+
+def test_save_per_log_pattern_creates_files(monkeypatch, tmp_path):
+    per_file = tmp_path / "per_log.json"
+    map_file = tmp_path / "map.json"
+    monkeypatch.setattr(json_utils, "PER_LOG_PATTERNS_PATH", str(per_file))
+    monkeypatch.setattr(json_utils, "LOG_KEY_MAP_PATH", str(map_file))
+
+    pat = {"regex": "a", "category": "C", "source": "builtin", "priority": 5}
+    json_utils.save_per_log_pattern("/var/log/app.log", "p1", pat, log_name="app")
+    assert per_file.exists()
+    assert map_file.exists()
+
+    with open(per_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert "app" in data
+    assert data["app"]["file"] == "/var/log/app.log"
+    assert "p1" in data["app"]["patterns"]
+    saved = data["app"]["patterns"]["p1"]
+    assert saved["category"] == "C"
+    assert saved["source"] == "builtin"
+    assert saved["priority"] == 5
+
+    with open(map_file, "r", encoding="utf-8") as f:
+        mapping = json.load(f)
+    assert mapping["app"]["file"] == "/var/log/app.log"
+
+    assert json_utils.get_log_name_for_file("/var/log/app.log") == "app"
+
+    loaded = json_utils.load_per_log_patterns_for_file("/var/log/app.log")
+    p = next(p for p in loaded if p["name"] == "p1")
+    assert p["category"] == "C"
+    assert p["source"] == "builtin"
+    assert p["priority"] == 5

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -22,14 +22,6 @@ def load_builtin_pattern_keys():
         return {}
 
 
-def load_builtin_pattern_keys():
-    try:
-        with open(BUILTIN_PATTERN_KEYS_PATH, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError):
-        return {}
-
-
 def load_all_patterns():
     """Загружает объединённые пользовательские и встроенные шаблоны."""
 
@@ -73,7 +65,7 @@ def load_per_log_patterns_for_file(source_file: str) -> list[dict]:
                     pat["regex"] = pat.pop("pattern")
                 pat.setdefault("name", pat_name)
                 pat.setdefault("enabled", True)
-                pat["source"] = "per_log"
+                pat.setdefault("source", "per_log")
                 result.append(pat)
             break
     return result
@@ -144,9 +136,34 @@ def get_log_name_for_file(source_file):
     return None
 
 
-def save_per_log_pattern(*args, **kwargs):
-    """Устаревшая совместимая функция."""
-    logger.warning("save_per_log_pattern is deprecated")
+def save_per_log_pattern(source_file, pattern_name, pattern_data, log_name=None):
+    """Сохраняет паттерн, привязанный к конкретному логу."""
+
+    try:
+        log_key = log_name if log_name else os.path.basename(source_file)
+
+        if os.path.exists(PER_LOG_PATTERNS_PATH):
+            with open(PER_LOG_PATTERNS_PATH, "r", encoding="utf-8") as f:
+                all_data = json.load(f)
+        else:
+            all_data = {}
+
+        entry = all_data.get(log_key, {"file": source_file, "patterns": {}})
+        entry["file"] = source_file
+        pat = pattern_data.copy()
+        if "regex" not in pat and "pattern" in pat:
+            pat["regex"] = pat.pop("pattern")
+        pat.setdefault("enabled", True)
+        entry.setdefault("patterns", {})[pattern_name] = pat
+        all_data[log_key] = entry
+
+        os.makedirs(os.path.dirname(PER_LOG_PATTERNS_PATH), exist_ok=True)
+        with open(PER_LOG_PATTERNS_PATH, "w", encoding="utf-8") as f:
+            json.dump(all_data, f, indent=4, ensure_ascii=False)
+
+        save_log_key_mapping(source_file, pattern_data.get("log_keys", []), log_name=log_name)
+    except Exception as e:
+        logger.error("[Ошибка сохранения пер-лог паттерна] %s", e)
 
 
 def load_cef_fields():


### PR DESCRIPTION
## Summary
- implement `save_per_log_pattern` to actually write per-log pattern data and update log-key mapping
- add regression test for `save_per_log_pattern`
- keep stored `source` and other fields when loading/saving per-log patterns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841cfd64f80832bbea3ded1a7293099