### PR TITLE
Fix per-log pattern overlay

### DIFF
--- a/tests/test_per_log_patterns.py
+++ b/tests/test_per_log_patterns.py
@@ -15,8 +15,8 @@ def test_load_per_log_patterns_for_file(tmp_path, monkeypatch):
         "log": {
             "file": "/var/log/app.log",
             "patterns": {
-                "A": {"regex": "foo"},
-                "B": {"regex": "bar"},
+                "A": {"regex": "foo", "category": "x", "priority": 1},
+                "B": {"regex": "bar", "source": "builtin"},
             },
         }
     }
@@ -26,7 +26,11 @@ def test_load_per_log_patterns_for_file(tmp_path, monkeypatch):
     patterns = json_utils.load_per_log_patterns_for_file("/var/log/app.log")
     names = {p["name"] for p in patterns}
     assert names == {"A", "B"}
-    assert all(p["source"] == "per_log" for p in patterns)
+    srcs = {p["source"] for p in patterns}
+    assert srcs == {"per_log", "builtin"}
+    cat = next(p for p in patterns if p["name"] == "A")
+    assert cat["category"] == "x"
+    assert cat["priority"] == 1
 
 
 def test_cache_matches_includes_per_log(monkeypatch):
@@ -49,3 +53,4 @@ def test_cache_matches_includes_per_log(monkeypatch):
 
     names = {m["name"] for m in app.match_cache[1]}
     assert names == {"A", "B"}
+    assert app.per_log_patterns == per_patterns

--- a/tests/test_save_per_log_pattern.py
+++ b/tests/test_save_per_log_pattern.py
@@ -1,0 +1,41 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils import json_utils
+
+
+def test_save_per_log_pattern_creates_files(monkeypatch, tmp_path):
+    per_file = tmp_path / "per_log.json"
+    map_file = tmp_path / "map.json"
+    monkeypatch.setattr(json_utils, "PER_LOG_PATTERNS_PATH", str(per_file))
+    monkeypatch.setattr(json_utils, "LOG_KEY_MAP_PATH", str(map_file))
+
+    pat = {"regex": "a", "category": "C", "source": "builtin", "priority": 5}
+    json_utils.save_per_log_pattern("/var/log/app.log", "p1", pat, log_name="app")
+    assert per_file.exists()
+    assert map_file.exists()
+
+    with open(per_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert "app" in data
+    assert data["app"]["file"] == "/var/log/app.log"
+    assert "p1" in data["app"]["patterns"]
+    saved = data["app"]["patterns"]["p1"]
+    assert saved["category"] == "C"
+    assert saved["source"] == "per_log"
+    assert saved["priority"] == 5
+
+    with open(map_file, "r", encoding="utf-8") as f:
+        mapping = json.load(f)
+    assert mapping["app"]["file"] == "/var/log/app.log"
+
+    assert json_utils.get_log_name_for_file("/var/log/app.log") == "app"
+
+    loaded = json_utils.load_per_log_patterns_for_file("/var/log/app.log")
+    p = next(p for p in loaded if p["name"] == "p1")
+    assert p["category"] == "C"
+    assert p["source"] == "per_log"
+    assert p["priority"] == 5


### PR DESCRIPTION
## Summary
- ensure per-log patterns are marked as `per_log` when saved
- keep loaded per-log patterns so GUI overlays persist after restart
- include log-specific patterns when rendering pages
- update tests for new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841cfd64f80832bbea3ded1a7293099