### PR TITLE
Enable tooltip for overlapping pattern names

### DIFF
--- a/core/regex_highlighter.py
+++ b/core/regex_highlighter.py
@@ -152,7 +152,8 @@ def apply_highlighting(
     text_widget,
     matches_by_line: Dict[int, List[Dict]],
     active_names: set,
-    color_map: Dict[str, str]
+    color_map: Dict[str, str],
+    tag_map: Dict[str, Dict] | None = None,
 ):
     # Import GUI and color utilities lazily to avoid unnecessary dependencies
     # when this module is used purely for match computation in tests.
@@ -165,6 +166,9 @@ def apply_highlighting(
             text_widget.tag_delete(tag)
         except tk.TclError:
             pass
+
+    if tag_map is not None:
+        tag_map.clear()
 
     pattern_keys = []
     seen = set()
@@ -194,6 +198,9 @@ def apply_highlighting(
                 text_widget.tag_config(tag, background=shaded, underline=m.get('overlap', False))
                 text_widget.tag_bind(tag, "<Enter>", lambda e, t=tag, c=hover: text_widget.tag_config(t, background=c))
                 text_widget.tag_bind(tag, "<Leave>", lambda e, t=tag, c=shaded: text_widget.tag_config(t, background=c))
+
+            if tag_map is not None:
+                tag_map[tag] = m
 
             start_idx = f"{lineno}.{m['start']}"
             end_idx = f"{lineno}.{m['end']}"

--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -32,6 +32,7 @@ class AppWindow(tk.Frame):
         self.tooltip = ToolTip(self)
         self.pattern_panel = None
         self.match_cache = {}  # lineno -> list of matches
+        self.tag_map = {}
         self.cef_fields = load_cef_fields()
 
         self._setup_widgets()
@@ -210,7 +211,7 @@ class AppWindow(tk.Frame):
                     )
 
         # Подсветка текста
-        apply_highlighting(self.text_area, matches_to_show, active_names, color_map)
+        apply_highlighting(self.text_area, matches_to_show, active_names, color_map, tag_map=self.tag_map)
 
         # Обновление панели справа
         self.pattern_panel.patterns = visible_patterns
@@ -244,10 +245,11 @@ class AppWindow(tk.Frame):
         try:
             index = self.text_area.index(f"@{event.x},{event.y}")
             tags = self.text_area.tag_names(index)
-            if tags:
-                tag = tags[0]
-                category, *_ = tag.split("_", 1)
-                self.tooltip.schedule(f"Категория: {category}", event.x_root, event.y_root)
+            names = [self.tag_map[t]["name"] for t in tags if t in self.tag_map]
+            if len(names) > 1:
+                self.tooltip.schedule(
+                    "Паттерны: " + ", ".join(names), event.x_root, event.y_root
+                )
             else:
                 self.tooltip.unschedule()
         except Exception:


### PR DESCRIPTION
## Summary
- extend `apply_highlighting` with optional `tag_map` parameter to map tags to matches
- keep track of created tag info in `AppWindow`
- display tooltip with all pattern names on overlapping highlights when hovering

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ecf01f24832b89fcf04726c86115