### PR TITLE
Auto-select category in pattern wizard

### DIFF
--- a/gui/pattern_wizard.py
+++ b/gui/pattern_wizard.py
@@ -33,7 +33,14 @@ class PatternWizardDialog(tk.Toplevel):
         
         self.context_lines = context_lines
         self.cef_fields = cef_fields
-        self.categories = categories or []
+        self.cef_category_map = {
+            f.get("key"): f.get("category") for f in self.cef_fields
+            if f.get("key") and f.get("category")
+        }
+        cef_categories = {
+            f.get("category") for f in self.cef_fields if f.get("category")
+        }
+        self.categories = sorted(set(categories or []) | cef_categories)
         self.source_file = source_file
         self.log_name = log_name
 
@@ -84,7 +91,14 @@ class PatternWizardDialog(tk.Toplevel):
         ttk.Entry(top_frame, textvariable=self.name_var, width=20).pack(side="left", padx=5)
 
         ttk.Label(top_frame, text="Категория:").pack(side="left")
-        ttk.Combobox(top_frame, textvariable=self.category_var, values=self.categories, width=20, state="readonly").pack(side="left", padx=5)
+        self.category_combo = ttk.Combobox(
+            top_frame,
+            textvariable=self.category_var,
+            values=self.categories,
+            width=20,
+            state="readonly",
+        )
+        self.category_combo.pack(side="left", padx=5)
 
         param_frame = ttk.Frame(self)
         param_frame.pack(fill="both", expand=True)
@@ -230,6 +244,7 @@ class PatternWizardDialog(tk.Toplevel):
         canvas.create_window((0, 0), window=self.cef_field_inner, anchor="nw")
 
         self._filter_cef_fields()
+        self._auto_select_category()
 
         # Кнопка сохранения
         ttk.Button(self, text="Сохранить", command=self._save).pack(pady=10)
@@ -448,6 +463,7 @@ class PatternWizardDialog(tk.Toplevel):
                 if not var:
                     var = tk.BooleanVar()
                     self.selected_field_vars[key] = var
+                    var.trace_add("write", lambda *_: self._auto_select_category())
                 chk = ttk.Checkbutton(
                     self.cef_field_inner,
                     text=key,
@@ -456,3 +472,19 @@ class PatternWizardDialog(tk.Toplevel):
                 chk.pack(anchor="w")
                 tip = f"{name}\nПример: {example}"
                 self._add_tip(chk, tip)
+
+    def _auto_select_category(self):
+        selected_keys = [k for k, v in self.selected_field_vars.items() if v.get()]
+        categories = {
+            self.cef_category_map.get(k)
+            for k in selected_keys
+            if self.cef_category_map.get(k)
+        }
+        if len(categories) == 1:
+            cat = next(iter(categories))
+            if cat not in self.categories:
+                self.categories.append(cat)
+                self.categories.sort()
+                if hasattr(self, "category_combo"):
+                    self.category_combo["values"] = self.categories
+            self.category_var.set(cat)

--- a/tests/test_pattern_wizard.py
+++ b/tests/test_pattern_wizard.py
@@ -16,6 +16,8 @@ class DummyVar:
         return self.value
     def set(self, v):
         self.value = v
+    def trace_add(self, mode, func):
+        pass
 
 
 class DummyFrame:
@@ -112,3 +114,25 @@ def test_filter_cef_fields(monkeypatch):
     wiz.cef_search_var.set("dst")
     PatternWizardDialog._filter_cef_fields(wiz)
     assert [c.text for c in wiz.cef_field_inner.children] == ["dst"]
+
+
+def test_auto_select_category_single():
+    wiz = PatternWizardDialog.__new__(PatternWizardDialog)
+    wiz.selected_field_vars = {"src": DummyVar(True)}
+    wiz.cef_category_map = {"src": "Network"}
+    wiz.categories = ["User", "Network"]
+    wiz.category_var = DummyVar()
+    wiz.category_combo = {"values": wiz.categories}
+    PatternWizardDialog._auto_select_category(wiz)
+    assert wiz.category_var.get() == "Network"
+
+
+def test_auto_select_category_multi():
+    wiz = PatternWizardDialog.__new__(PatternWizardDialog)
+    wiz.selected_field_vars = {"src": DummyVar(True), "user": DummyVar(True)}
+    wiz.cef_category_map = {"src": "Network", "user": "User"}
+    wiz.categories = ["Network", "User"]
+    wiz.category_var = DummyVar("Initial")
+    wiz.category_combo = {"values": wiz.categories}
+    PatternWizardDialog._auto_select_category(wiz)
+    assert wiz.category_var.get() == "Initial"


### PR DESCRIPTION
## Summary
- auto populate category list with CEF categories
- change category combobox to be accessible
- automatically select the category that matches the chosen CEF field
- tests for auto selecting category

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f62bb244832ba91cf9e5cfe8c760