### PR TITLE
Implement CEF code generator logic

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -13,6 +13,7 @@ from gui.pattern_panel import PatternPanel
 from utils.color_utils import generate_distinct_colors
 from gui.tooltip import ToolTip
 from gui.pattern_wizard import PatternWizardDialog
+from gui.code_generator_dialog import CodeGeneratorDialog
 from utils.text_utils import compute_char_coverage
 import logging
 import re
@@ -88,6 +89,7 @@ class AppWindow(tk.Frame):
         self.coverage_label.pack(side="left", padx=15)
         tk.Button(ctrl, text="Создать паттерн", command=self.open_pattern_wizard).pack(side="left", padx=5)
         tk.Button(ctrl, text="Сохранить паттерны", command=self.save_current_patterns).pack(side="left", padx=5)
+        tk.Button(ctrl, text="Генератор кода", command=self.open_code_generator).pack(side="left", padx=5)
         self.text_area.bind("<Motion>", self.on_hover)
         self.text_area.bind("<Leave>", lambda e: self.tooltip.hidetip())
 
@@ -302,6 +304,15 @@ class AppWindow(tk.Frame):
         except Exception as e:
             logger.error("[PatternWizard] %s", e)
             messagebox.showerror("Ошибка", f"Не удалось открыть мастер: {e}")
+
+    def open_code_generator(self):
+        """Open the code generator dialog (stub)."""
+        try:
+            dlg = CodeGeneratorDialog(self, per_log_patterns=self.per_log_patterns)
+            dlg.grab_set()
+        except Exception as e:
+            logger.error("[CodeGenerator] %s", e)
+            messagebox.showerror("Ошибка", f"Не удалось открыть генератор: {e}")
 
     def get_selected_lines(self):
         """Return selected fragments along with their full line context."""

--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -1,0 +1,151 @@
+import os
+import tkinter as tk
+from tkinter import ttk, messagebox, simpledialog
+
+from gui.transform_editor import TransformEditorDialog
+
+
+from utils import json_utils, code_generator
+
+
+class CodeGeneratorDialog(tk.Toplevel):
+    """Dialog for configuring and generating CEF converter code."""
+
+    def __init__(self, parent, per_log_patterns=None):
+        super().__init__(parent)
+        self.title("CEF Code Generator Dialog")
+        self.minsize(600, 400)
+        self.per_log_patterns = per_log_patterns or []
+
+        self._build_ui()
+
+    def _build_ui(self):
+        top = ttk.Frame(self)
+        top.pack(fill="x", padx=10, pady=5)
+        ttk.Label(top, text="Source Pattern Key:").grid(row=0, column=0, sticky="w")
+        pattern_names = [p.get("name") for p in self.per_log_patterns]
+        self.pattern_var = tk.StringVar()
+        combo = ttk.Combobox(top, textvariable=self.pattern_var, values=pattern_names, state="readonly")
+        combo.grid(row=0, column=1, sticky="ew")
+        top.grid_columnconfigure(1, weight=1)
+
+        header = ttk.LabelFrame(self, text="CEF Header")
+        header.pack(fill="x", padx=10, pady=5)
+
+        self.header_vars = {}
+        fields = [
+            ("CEF Version", "0"),
+            ("Device Vendor", "ACME"),
+            ("Device Product", "LogParserPro"),
+            ("Device Version", "1.0.0"),
+            ("Event Class ID", "42"),
+            ("Event Name", "LoginAttempt"),
+            ("Severity (int)", "5"),
+        ]
+        for i, (label, default) in enumerate(fields):
+            ttk.Label(header, text=f"{label}:").grid(row=i, column=0, sticky="w", pady=2, padx=2)
+            var = tk.StringVar(value=default)
+            entry = ttk.Entry(header, textvariable=var)
+            if label == "CEF Version":
+                entry.config(state="disabled")
+            entry.grid(row=i, column=1, sticky="ew", pady=2, padx=2)
+            self.header_vars[label] = var
+        header.grid_columnconfigure(1, weight=1)
+
+        fields_frame = ttk.LabelFrame(self, text="Fields Auto-Mapped from Regex Patterns")
+        fields_frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        columns = ("cef_field", "source", "transform", "preview")
+        self.tree = ttk.Treeview(fields_frame, columns=columns, show="headings", height=5)
+        for col in columns:
+            heading = "CEF Fields" if col == "cef_field" else col.title()
+            self.tree.heading(col, text=heading)
+        self.tree.pack(fill="both", expand=True)
+        self.tree.bind("<Double-1>", self._on_edit)
+
+        # sample initial rows
+        self.tree.insert("", "end", values=("time", "ISODate", "none", ""))
+        self.tree.insert("", "end", values=("user", "UserName", "none", ""))
+        self.tree.insert("", "end", values=("msg", "Message", "none", ""))
+
+        btns = ttk.Frame(self)
+        btns.pack(fill="x", pady=5)
+        ttk.Button(btns, text="+ Add Field", command=self._on_add_field).pack(side="left", padx=5)
+        ttk.Button(btns, text="Preview Code ▸", command=self._on_preview).pack(side="right", padx=5)
+        ttk.Button(btns, text="Generate Python", command=self._on_generate).pack(side="right", padx=5)
+
+    def _collect_patterns(self) -> list:
+        patterns = {p["name"]: p for p in json_utils.load_all_patterns()}
+        for p in self.per_log_patterns:
+            patterns[p.get("name")] = p
+        return [
+            {"name": name, "regex": pat.get("regex", pat.get("pattern", ""))}
+            for name, pat in patterns.items()
+        ]
+
+    def _row_to_mapping(self, item):
+        values = self.tree.item(item, "values")
+        return {
+            "cef": values[0],
+            "pattern": values[1],
+            "group": 0,
+            "transform": values[2] or "none",
+        }
+
+    def _on_add_field(self):
+        cef_field = simpledialog.askstring("CEF Field", "Enter CEF field key")
+        if not cef_field:
+            return
+        pattern = simpledialog.askstring("Source Pattern", "Enter pattern name")
+        if not pattern:
+            return
+        self.tree.insert("", "end", values=(cef_field, pattern, "none", ""))
+
+    def _on_preview(self):
+        # generate code into a temporary directory and show the converter code
+        import tempfile, pathlib
+
+        header = {k: v.get() for k, v in self.header_vars.items()}
+        mappings = [self._row_to_mapping(item) for item in self.tree.get_children()]
+        patterns = self._collect_patterns()
+
+        tmp_dir = tempfile.mkdtemp()
+        paths = code_generator.generate_files(header, mappings, patterns, tmp_dir)
+        converter_path = pathlib.Path(paths[0])
+        try:
+            with open(converter_path, "r", encoding="utf-8") as f:
+                data = f.read()
+        except OSError as e:
+            messagebox.showerror("Error", str(e))
+            return
+
+        preview = tk.Toplevel(self)
+        preview.title("Generated cef_converter.py")
+        text = tk.Text(preview, wrap="none")
+        text.insert("1.0", data)
+        text.pack(fill="both", expand=True)
+
+    def _on_generate(self):
+        header = {k: v.get() for k, v in self.header_vars.items()}
+        mappings = [self._row_to_mapping(item) for item in self.tree.get_children()]
+        patterns = self._collect_patterns()
+        out_dir = os.path.join(os.getcwd(), "generated_cef")
+        try:
+            code_generator.generate_files(header, mappings, patterns, out_dir)
+            messagebox.showinfo("Success", f"Files written to {out_dir}")
+        except Exception as e:
+            messagebox.showerror("Error", str(e))
+
+    def _on_edit(self, event):
+        item = self.tree.identify_row(event.y)
+        if not item:
+            return
+        values = self.tree.item(item, "values")
+        cef_field, pattern, transform = values[:3]
+        dlg = TransformEditorDialog(self, cef_field, current=transform)
+        dlg.grab_set()
+        self.wait_window(dlg)
+        if dlg.result is not None:
+            self.tree.item(item, values=(cef_field, pattern, dlg.result, values[3]))
+
+

--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -1,0 +1,34 @@
+import tkinter as tk
+from tkinter import ttk
+
+
+class TransformEditorDialog(tk.Toplevel):
+    """Dialog for selecting a basic value transformation."""
+
+    TRANSFORMS = [
+        ("none", "as is"),
+        ("lower", "lower case"),
+        ("upper", "UPPER CASE"),
+        ("capitalize", "Capitalized"),
+        ("sentence", "Sentence case"),
+    ]
+
+    def __init__(self, parent, cef_field: str, current: str = "none"):
+        super().__init__(parent)
+        self.result = None
+        self.title(f"Transform Editor for CEF Field: {cef_field}")
+        self.minsize(300, 200)
+
+        ttk.Label(self, text="Formatting:").pack(anchor="w", padx=10, pady=(10, 5))
+        self.var = tk.StringVar(value=current)
+        for value, label in self.TRANSFORMS:
+            ttk.Radiobutton(self, text=label, variable=self.var, value=value).pack(anchor="w", padx=20)
+
+        btns = ttk.Frame(self)
+        btns.pack(pady=10)
+        ttk.Button(btns, text="Save", command=self._on_save).pack(side="left", padx=5)
+        ttk.Button(btns, text="Cancel", command=self.destroy).pack(side="left", padx=5)
+
+    def _on_save(self):
+        self.result = self.var.get()
+        self.destroy()

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from importlib.machinery import SourceFileLoader
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils.code_generator import generate_files
+
+
+def test_generate_files_and_converter(tmp_path):
+    header = {
+        'CEF Version': '0',
+        'Device Vendor': 'ACME',
+        'Device Product': 'LP',
+        'Device Version': '1.0',
+        'Event Class ID': '42',
+        'Event Name': 'Test',
+        'Severity (int)': '5',
+    }
+    patterns = [{
+        'name': 'UserName',
+        'regex': r'user=(\w+)',
+    }]
+    mappings = [{
+        'cef': 'suser',
+        'pattern': 'UserName',
+        'group': 1,
+        'transform': 'upper',
+    }]
+
+    paths = generate_files(header, mappings, patterns, tmp_path)
+    conv_path = os.path.join(tmp_path, 'cef_converter.py')
+    assert conv_path in paths
+
+    loader = SourceFileLoader('cef_converter', conv_path)
+    module = loader.load_module()
+    conv = module.LogToCEFConverter()
+    result = conv.convert_line('user=john')
+    assert 'ACME' in result and 'JOHN' in result
+

--- a/tests/test_transform_logic.py
+++ b/tests/test_transform_logic.py
@@ -1,0 +1,14 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from utils.transform_logic import apply_transform
+
+
+def test_apply_transform_modes():
+    assert apply_transform('TeSt', 'lower') == 'test'
+    assert apply_transform('TeSt', 'upper') == 'TEST'
+    assert apply_transform('john', 'capitalize') == 'John'
+    assert apply_transform('hello WORLD', 'sentence') == 'Hello world'
+    assert apply_transform('Same', 'none') == 'Same'

--- a/utils/code_generator.py
+++ b/utils/code_generator.py
@@ -1,0 +1,102 @@
+"""Generate CEF converter class and helper script."""
+
+from __future__ import annotations
+
+import os
+from textwrap import dedent
+from typing import List, Dict
+
+
+def generate_files(header: Dict[str, str], mappings: List[Dict], patterns: List[Dict], output_dir: str) -> list[str]:
+    """Generate converter and main script files.
+
+    Parameters
+    ----------
+    header : dict
+        Values for CEF header fields.
+    mappings : list of dict
+        Mapping definitions: {'cef': key, 'pattern': pattern_name, 'group': int, 'transform': str}
+    patterns : list of dict
+        Available patterns with 'name' and 'regex'.
+    output_dir : str
+        Directory to write generated files.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    converter_path = os.path.join(output_dir, "cef_converter.py")
+    main_path = os.path.join(output_dir, "main_cef_converter.py")
+
+    header_repr = "{\n" + ",\n".join(f"    '{k}': '{v}'" for k, v in header.items()) + "\n}"
+    pattern_repr = "{\n" + ",\n".join(
+        f"    '{p['name']}': re.compile(r'''{p['regex']}''')" for p in patterns) + "\n}"
+    mapping_repr = "[\n" + ",\n".join(
+        "    {" + ", ".join([
+            f"'cef': '{m['cef']}'",
+            f"'pattern': '{m['pattern']}'",
+            f"'group': {int(m.get('group', 0))}",
+            f"'transform': '{m.get('transform', 'none')}'"
+        ]) + "}" for m in mappings) + "\n]"
+
+    converter_code = f"""
+import re
+from utils.transform_logic import apply_transform
+
+class LogToCEFConverter:
+    def __init__(self):
+        self.compiled_patterns = {pattern_repr}
+        self.mappings = {mapping_repr}
+        self.cef_header = {header_repr}
+
+    def convert_line(self, line: str) -> str:
+        matches = {{name: rgx.search(line) for name, rgx in self.compiled_patterns.items()}}
+        fields = {{}}
+        for m in self.mappings:
+            match = matches.get(m['pattern'])
+            value = match.group(m['group']) if match else ''
+            fields[m['cef']] = apply_transform(value, m['transform'])
+        return self._build_cef_string(fields)
+
+    def _build_cef_string(self, fields: dict) -> str:
+        h = self.cef_header
+        head = f"CEF:{{h.get('CEF Version')}}|{{h.get('Device Vendor')}}|{{h.get('Device Product')}}|{{h.get('Device Version')}}|{{h.get('Event Class ID')}}|{{h.get('Event Name')}}|{{h.get('Severity (int)')}}"
+        ext = ' '.join(f"{{k}}={{v}}" for k, v in fields.items() if v)
+        return head + '|' + ext
+
+    def coverage_score(self, line: str) -> float:
+        matches = [rgx.search(line) for rgx in self.compiled_patterns.values()]
+        covered = sum(len(m.group(0)) for m in matches if m)
+        significant = ''.join(ch for ch in line if ch.isalnum())
+        return 100.0 if not significant else covered / len(significant) * 100
+
+    def log_incomplete_coverage(self, line: str, coverage: float, fp):
+        fp.write(f"{{line}} | coverage={{coverage:.1f}}%\\n")
+"""
+
+    main_code = dedent("""
+    from cef_converter import LogToCEFConverter
+
+    def main():
+        conv = LogToCEFConverter()
+        with open('input.log', 'r', encoding='utf-8') as fin, \
+             open('output.cef', 'w', encoding='utf-8') as fout, \
+             open('error.log', 'w', encoding='utf-8') as ferr:
+            for line in fin:
+                line = line.rstrip('\n')
+                cef = conv.convert_line(line)
+                fout.write(cef + '\n')
+                cov = conv.coverage_score(line)
+                if cov < 100.0:
+                    conv.log_incomplete_coverage(line, cov, ferr)
+
+    if __name__ == '__main__':
+        main()
+    """)
+
+    with open(converter_path, 'w', encoding='utf-8') as f:
+        f.write(converter_code)
+    with open(main_path, 'w', encoding='utf-8') as f:
+        f.write(main_code)
+
+    return [converter_path, main_path]
+
+

--- a/utils/transform_logic.py
+++ b/utils/transform_logic.py
@@ -1,0 +1,20 @@
+"""Simple transformation helpers for CEF field values."""
+
+from typing import Any
+
+
+def apply_transform(value: str, transform: str) -> str:
+    """Apply a basic string transformation."""
+    if value is None:
+        value = ""
+    if transform == "lower":
+        return value.lower()
+    if transform == "upper":
+        return value.upper()
+    if transform == "capitalize":
+        return value.capitalize()
+    if transform == "sentence":
+        return value[:1].upper() + value[1:].lower() if value else value
+    return value
+
+


### PR DESCRIPTION
## Summary
- flesh out `CodeGeneratorDialog` with real actions
- add transformation editor with selectable options
- implement `generate_files` helper and value transforms
- provide unit tests for transform logic and generated converter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fbd995fc832b83f84c34908ca6ff