### PR TITLE
Add key-based selection of per-log patterns

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -6,6 +6,8 @@ from utils.json_utils import (
     get_log_name_for_file,
     get_log_keys_for_file,
     load_per_log_patterns_for_file,
+    load_per_log_patterns_by_key,
+    load_log_key_map,
     save_per_log_pattern,
 )
 from core.regex_highlighter import find_matches_in_line, apply_highlighting
@@ -308,7 +310,16 @@ class AppWindow(tk.Frame):
     def open_code_generator(self):
         """Open the code generator dialog (stub)."""
         try:
-            dlg = CodeGeneratorDialog(self, per_log_patterns=self.per_log_patterns)
+            per_patterns = list(self.per_log_patterns)
+            if not per_patterns:
+                keys = list(load_log_key_map().keys())
+                if keys:
+                    prompt = "Выберите ключ лог-файла:\n" + ", ".join(keys)
+                    key = simpledialog.askstring("Log Key", prompt, parent=self)
+                    if key:
+                        per_patterns = load_per_log_patterns_by_key(key)
+
+            dlg = CodeGeneratorDialog(self, per_log_patterns=per_patterns, logs=self.logs)
             dlg.grab_set()
         except Exception as e:
             logger.error("[CodeGenerator] %s", e)

--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -12,11 +12,12 @@ from utils import json_utils, code_generator
 class CodeGeneratorDialog(tk.Toplevel):
     """Dialog for configuring and generating CEF converter code."""
 
-    def __init__(self, parent, per_log_patterns=None):
+    def __init__(self, parent, per_log_patterns=None, logs=None):
         super().__init__(parent)
         self.title("CEF Code Generator Dialog")
         self.minsize(600, 400)
         self.per_log_patterns = per_log_patterns or []
+        self.logs = logs or []
 
         self._build_ui()
 
@@ -25,7 +26,7 @@ class CodeGeneratorDialog(tk.Toplevel):
         top.pack(fill="x", padx=10, pady=5)
         ttk.Label(top, text="Source Pattern Key:").grid(row=0, column=0, sticky="w")
         pattern_names = [p.get("name") for p in self.per_log_patterns]
-        self.pattern_var = tk.StringVar()
+        self.pattern_var = tk.StringVar(value=pattern_names[0] if pattern_names else "")
         combo = ttk.Combobox(top, textvariable=self.pattern_var, values=pattern_names, state="readonly")
         combo.grid(row=0, column=1, sticky="ew")
         top.grid_columnconfigure(1, weight=1)
@@ -74,6 +75,13 @@ class CodeGeneratorDialog(tk.Toplevel):
         ttk.Button(btns, text="+ Add Field", command=self._on_add_field).pack(side="left", padx=5)
         ttk.Button(btns, text="Preview Code ▸", command=self._on_preview).pack(side="right", padx=5)
         ttk.Button(btns, text="Generate Python", command=self._on_generate).pack(side="right", padx=5)
+
+        self.pattern_frame = ttk.LabelFrame(self, text="Used Patterns")
+        self.pattern_frame.pack(fill="x", padx=10, pady=5)
+        self.pattern_list = ttk.Frame(self.pattern_frame)
+        self.pattern_list.pack(fill="x", expand=True)
+
+        self._refresh_pattern_list()
 
     def _collect_patterns(self) -> list:
         patterns = {p["name"]: p for p in json_utils.load_all_patterns()}
@@ -149,3 +157,49 @@ class CodeGeneratorDialog(tk.Toplevel):
         self.wait_window(dlg)
         if dlg.result is not None:
             self.tree.item(item, values=(cef_field, pattern, dlg.result, values[3]))
+            self._refresh_pattern_list()
+
+    def _edit_mapping(self, item):
+        values = self.tree.item(item, "values")
+        cef_field, pattern, transform = values[:3]
+        dlg = TransformEditorDialog(self, cef_field, current=transform)
+        dlg.grab_set()
+        self.wait_window(dlg)
+        if dlg.result is not None:
+            self.tree.item(item, values=(cef_field, pattern, dlg.result, values[3]))
+            self._refresh_pattern_list()
+
+    def _find_example(self, regex: str) -> str:
+        import re
+
+        try:
+            pat = re.compile(regex)
+        except re.error:
+            return ""
+        for line in self.logs:
+            m = pat.search(line)
+            if m:
+                return m.group(0)
+        return ""
+
+    def _refresh_pattern_list(self):
+        for child in self.pattern_list.winfo_children():
+            child.destroy()
+
+        headers = ["Name", "Regex", "CEF", "Transform", "Example"]
+        for col, text in enumerate(headers):
+            ttk.Label(self.pattern_list, text=text, font=("Segoe UI", 9, "bold")).grid(row=0, column=col, sticky="w", padx=2)
+
+        pattern_map = {p["name"]: p for p in self._collect_patterns()}
+
+        for row, item in enumerate(self.tree.get_children(), start=1):
+            mapping = self._row_to_mapping(item)
+            pat = pattern_map.get(mapping["pattern"], {"name": mapping["pattern"], "regex": ""})
+            example = self._find_example(pat.get("regex", ""))
+            ttk.Label(self.pattern_list, text=pat["name"]).grid(row=row, column=0, sticky="w", padx=2)
+            ttk.Label(self.pattern_list, text=pat.get("regex", "")).grid(row=row, column=1, sticky="w", padx=2)
+            ttk.Label(self.pattern_list, text=mapping["cef"]).grid(row=row, column=2, sticky="w", padx=2)
+            ttk.Button(self.pattern_list, text=mapping["transform"], command=lambda i=item: self._edit_mapping(i)).grid(row=row, column=3, sticky="w", padx=2)
+            ttk.Label(self.pattern_list, text=example).grid(row=row, column=4, sticky="w", padx=2)
+
+

--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -1,0 +1,12 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from gui.code_generator_dialog import CodeGeneratorDialog
+
+
+def test_find_example():
+    dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
+    dlg.logs = ["user=john", "error 42"]
+    assert dlg._find_example(r"user=\w+") == "user=john"
+    assert dlg._find_example(r"error") == "error"

--- a/tests/test_open_code_generator.py
+++ b/tests/test_open_code_generator.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from gui.app_window import AppWindow
+from utils import json_utils
+
+
+def test_open_code_generator_selects_key(monkeypatch):
+    app = AppWindow.__new__(AppWindow)
+    app.per_log_patterns = []
+    app.source_path = None
+    app.logs = []
+
+    monkeypatch.setattr(json_utils, "load_log_key_map", lambda: {"app": {"file": "log", "keys": []}})
+    monkeypatch.setattr(json_utils, "load_per_log_patterns_by_key", lambda k: [{"name": "A", "regex": "foo", "source": "per_log"}])
+
+    import gui.app_window as app_mod
+
+    monkeypatch.setattr(app_mod, "load_log_key_map", lambda: {"app": {"file": "log", "keys": []}})
+    monkeypatch.setattr(app_mod, "load_per_log_patterns_by_key", lambda k: [{"name": "A", "regex": "foo", "source": "per_log"}])
+    monkeypatch.setattr(app_mod.simpledialog, "askstring", lambda *a, **k: "app")
+    monkeypatch.setattr(app_mod.messagebox, "showerror", lambda *a, **k: None)
+
+    captured = {}
+
+    class DummyDialog:
+        def __init__(self, parent, per_log_patterns=None, logs=None):
+            captured["patterns"] = per_log_patterns
+            captured["logs"] = logs
+        def grab_set(self):
+            pass
+
+    monkeypatch.setattr(app_mod, "CodeGeneratorDialog", DummyDialog)
+
+    AppWindow.open_code_generator(app)
+
+    assert captured["patterns"][0]["name"] == "A"
+    assert captured["logs"] == []

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -71,6 +71,31 @@ def load_per_log_patterns_for_file(source_file: str) -> list[dict]:
     return result
 
 
+def load_per_log_patterns_by_key(log_key: str) -> list[dict]:
+    """Return patterns associated with a saved log key."""
+
+    try:
+        with open(PER_LOG_PATTERNS_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+
+    entry = data.get(log_key)
+    if not entry:
+        return []
+
+    result = []
+    for pat_name, pat in entry.get("patterns", {}).items():
+        pat = pat.copy()
+        if "regex" not in pat and "pattern" in pat:
+            pat["regex"] = pat.pop("pattern")
+        pat.setdefault("name", pat_name)
+        pat.setdefault("enabled", True)
+        pat.setdefault("source", "per_log")
+        result.append(pat)
+    return result
+
+
 def save_user_patterns(patterns):
     """Сохраняет пользовательские шаблоны."""
     to_save = {"patterns": patterns}


### PR DESCRIPTION
## Summary
- allow generating CEF code using patterns from a selected log key
- preselect first per-log pattern name in generator dialog
- expose `load_per_log_patterns_by_key` helper
- test new helper and key selection behaviour
- show used patterns list in code generator dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420c57ac8c832b8c47f7f9fc7de7f8