### PR TITLE
Fix duplicate mandatory fields in code generator dialog

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -62,8 +62,6 @@ class CodeGeneratorDialog(tk.Toplevel):
         ttk.Button(btns, text="+ Add Field", command=self._on_add_field).pack(side="left", padx=5)
         ttk.Button(btns, text="Preview Code ▸", command=self._on_preview).pack(side="right", padx=5)
         ttk.Button(btns, text="Generate Python", command=self._on_generate).pack(side="right", padx=5)
-        for key in self.MANDATORY_FIELDS:
-            self.mappings.append({"cef": key, "pattern": "", "transform": "none"})
 
         self._refresh_mapping_list()
 

--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -24,3 +24,21 @@ def test_initial_mappings_duplicate(monkeypatch):
     mappings = CodeGeneratorDialog._build_initial_mappings(dlg)
     dv = [m for m in mappings if m["cef"] == "deviceVendor"]
     assert len(dv) == 2
+
+
+def test_dialog_init_no_duplicate(monkeypatch):
+    patterns = [{"name": "deviceVendor", "regex": "foo"}]
+
+    monkeypatch.setattr(CodeGeneratorDialog, "_collect_patterns", lambda self: patterns)
+    monkeypatch.setattr(json_utils, "load_cef_field_keys", lambda: ["deviceVendor"])
+
+    monkeypatch.setattr(CodeGeneratorDialog, "_build_ui", lambda self: None)
+    dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
+    dlg.per_log_patterns = patterns
+    dlg.logs = []
+    dlg.mappings = CodeGeneratorDialog._build_initial_mappings(dlg)
+    CodeGeneratorDialog._build_ui(dlg)
+
+    dv = [m for m in dlg.mappings if m["cef"] == "deviceVendor"]
+    assert len(dv) == 1
+


### PR DESCRIPTION
## Summary
- remove redundant mandatory field injection in `CodeGeneratorDialog`
- add regression test ensuring no duplicate mandatory mappings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842359ce918832b9d851a99fb1ece08