### PR TITLE
Auto-map CEF fields using per-log patterns only

### DIFF
--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -42,3 +42,24 @@ def test_dialog_init_no_duplicate(monkeypatch):
     dv = [m for m in dlg.mappings if m["cef"] == "deviceVendor"]
     assert len(dv) == 1
 
+
+def test_initial_mappings_from_fields(monkeypatch):
+    dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
+
+    patterns = [
+        {"name": "Date L", "regex": "foo", "fields": ["start"]},
+        {"name": "Time Range", "regex": "bar", "fields": ["start", "end"]},
+    ]
+
+    dlg.per_log_patterns = patterns
+    monkeypatch.setattr(CodeGeneratorDialog, "_collect_patterns", lambda self: patterns)
+    monkeypatch.setattr(json_utils, "load_cef_field_keys", lambda: ["start", "end"])
+
+    mappings = CodeGeneratorDialog._build_initial_mappings(dlg)
+    start = [m["pattern"] for m in mappings if m["cef"] == "start"]
+    end = [m["pattern"] for m in mappings if m["cef"] == "end"]
+
+    assert start.count("Date L") == 1
+    assert start.count("Time Range") == 1
+    assert end == ["Time Range"]
+


### PR DESCRIPTION
## Summary
- restrict initial CEF field mapping to patterns defined for the selected log file
- update unit test to provide per-log patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684237ee87b8832babf2a82a78d4b511