### PR TITLE
Implement CEF field selection for builtin pattern saving

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -16,6 +16,7 @@ from utils.color_utils import generate_distinct_colors
 from gui.tooltip import ToolTip
 from gui.pattern_wizard import PatternWizardDialog
 from gui.code_generator_dialog import CodeGeneratorDialog
+from gui.cef_field_dialog import CEFFieldDialog
 from utils.text_utils import compute_char_coverage
 import logging
 import re
@@ -373,7 +374,22 @@ class AppWindow(tk.Frame):
             p for p in self.patterns
             if p["name"] in matched_names and p.get("enabled", True)
         ]
+
         for pat in patterns_to_save:
-            save_per_log_pattern(self.source_path, pat["name"], pat, log_name=log_name)
+            data = pat.copy()
+            if data.get("source") == "builtin":
+                dlg = CEFFieldDialog(
+                    self,
+                    self.cef_fields,
+                    data.get("name", ""),
+                    initial=data.get("fields", [])
+                )
+                dlg.grab_set()
+                self.wait_window(dlg)
+                if dlg.result is None:
+                    continue
+                data["fields"] = dlg.result
+
+            save_per_log_pattern(self.source_path, data["name"], data, log_name=log_name)
 
         messagebox.showinfo("Готово", "Паттерны сохранены.")

--- a/gui/cef_field_dialog.py
+++ b/gui/cef_field_dialog.py
@@ -1,0 +1,49 @@
+import tkinter as tk
+from tkinter import ttk
+
+
+class CEFFieldDialog(tk.Toplevel):
+    """Dialog for selecting CEF fields for a pattern."""
+
+    def __init__(self, parent, cef_fields, pattern_name: str, initial=None):
+        super().__init__(parent)
+        self.title(f"CEF-поля для {pattern_name}")
+        self.result = None
+        self.var_map = {}
+        self.cef_fields = cef_fields or []
+        self.initial = set(initial or [])
+        self._build_ui()
+
+    def _build_ui(self):
+        frame = ttk.Frame(self)
+        frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        canvas = tk.Canvas(frame, height=200)
+        scroll = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
+        canvas.configure(yscrollcommand=scroll.set)
+        canvas.pack(side="left", fill="both", expand=True)
+        scroll.pack(side="right", fill="y")
+
+        inner = ttk.Frame(canvas)
+        inner.bind("<Configure>", lambda e: canvas.configure(scrollregion=canvas.bbox("all")))
+        canvas.create_window((0, 0), window=inner, anchor="nw")
+
+        for field in self.cef_fields:
+            key = field.get("key", "")
+            var = tk.BooleanVar(value=key in self.initial)
+            chk = ttk.Checkbutton(inner, text=key, variable=var)
+            chk.pack(anchor="w")
+            self.var_map[key] = var
+
+        btns = ttk.Frame(self)
+        btns.pack(pady=5)
+        ttk.Button(btns, text="OK", command=self._on_ok).pack(side="left", padx=5)
+        ttk.Button(btns, text="Cancel", command=self._on_cancel).pack(side="left", padx=5)
+
+    def _on_ok(self):
+        self.result = [k for k, v in self.var_map.items() if v.get()]
+        self.destroy()
+
+    def _on_cancel(self):
+        self.result = None
+        self.destroy()


### PR DESCRIPTION
## Summary
- ask for CEF fields when saving builtin patterns from main window
- add `CEFFieldDialog` to choose fields interactively

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842420334c0832b95ea3b83230f0b0d