### PR TITLE
Fix pattern list refresh after save

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -392,4 +392,8 @@ class AppWindow(tk.Frame):
 
             save_per_log_pattern(self.source_path, data["name"], data, log_name=log_name)
 
+        # Reload per-log patterns and matches so other dialogs see updates
+        self._cache_matches()
+        self.render_page()
+
         messagebox.showinfo("Готово", "Паттерны сохранены.")


### PR DESCRIPTION
## Summary
- refresh cached matches and UI after saving per-log patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424457eb28832b9349ed6d74e01dea