### PR TITLE
Show regex match examples with transformations

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -130,6 +130,37 @@ class CodeGeneratorDialog(tk.Toplevel):
                 return m.group(0)
         return ""
 
+    def _find_examples(self, regex: str, max_lines: int = 5) -> list[str]:
+        """Return unique captured segments for the regex."""
+        import re
+
+        try:
+            pat = re.compile(regex)
+        except re.error:
+            return []
+
+        result = []
+        seen = set()
+        for line in self.logs:
+            m = pat.search(line)
+            if not m:
+                continue
+
+            if m.lastindex:
+                if m.lastindex == 1:
+                    value = m.group(1)
+                else:
+                    value = " ".join(m.group(i) for i in range(1, m.lastindex + 1))
+            else:
+                value = m.group(0)
+
+            if value not in seen:
+                seen.add(value)
+                result.append(value)
+                if len(result) >= max_lines:
+                    break
+        return result
+
     def _choose_cef_field(self):
         keys = json_utils.load_cef_field_keys()
         if not keys:
@@ -169,7 +200,10 @@ class CodeGeneratorDialog(tk.Toplevel):
 
     def _on_edit_transform(self, idx):
         m = self.mappings[idx]
-        dlg = TransformEditorDialog(self, m["cef"], current=m["transform"])
+        pattern_map = {p["name"]: p for p in self._collect_patterns()}
+        regex = pattern_map.get(m.get("pattern"), {}).get("regex", "")
+        examples = self._find_examples(regex) if regex else []
+        dlg = TransformEditorDialog(self, m["cef"], current=m["transform"], regex=regex, examples=examples)
         dlg.grab_set()
         self.wait_window(dlg)
         if dlg.result is not None:
@@ -258,7 +292,8 @@ class CodeGeneratorDialog(tk.Toplevel):
                 entry.grid(row=idx, column=1, sticky="ew", padx=2)
                 entry.bind("<KeyRelease>", lambda e, i=idx-1, v=var: self._on_value_changed(i, v))
             ttk.Label(self.mapping_list, text=regex).grid(row=idx, column=2, sticky="w", padx=2)
-            ttk.Button(self.mapping_list, text=m["transform"], command=lambda i=idx-1: self._on_edit_transform(i)).grid(row=idx, column=3, sticky="w", padx=2)
+            btn_text = m["transform"] if isinstance(m.get("transform"), str) else "custom"
+            ttk.Button(self.mapping_list, text=btn_text, command=lambda i=idx-1: self._on_edit_transform(i)).grid(row=idx, column=3, sticky="w", padx=2)
             ttk.Label(self.mapping_list, text=example).grid(row=idx, column=4, sticky="w", padx=2)
 
         self.mapping_list.grid_columnconfigure(1, weight=1)

--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -1,9 +1,11 @@
 import tkinter as tk
 from tkinter import ttk
 
+from utils.transform_logic import apply_transform
+
 
 class TransformEditorDialog(tk.Toplevel):
-    """Dialog for selecting a basic value transformation."""
+    """Dialog for selecting a basic or advanced value transformation."""
 
     TRANSFORMS = [
         ("none", "as is"),
@@ -13,22 +15,109 @@ class TransformEditorDialog(tk.Toplevel):
         ("sentence", "Sentence case"),
     ]
 
-    def __init__(self, parent, cef_field: str, current: str = "none"):
+    def __init__(self, parent, cef_field: str, current: object = "none", *, regex: str = "", examples: list[str] | None = None):
         super().__init__(parent)
         self.result = None
         self.title(f"Transform Editor for CEF Field: {cef_field}")
-        self.minsize(300, 200)
+        self.minsize(300, 360)
+
+        self.examples = examples or []
+        if regex:
+            ttk.Label(self, text="Regex:").pack(anchor="w", padx=10, pady=(5, 0))
+            regex_box = tk.Text(self, height=1, width=40)
+            regex_box.insert("1.0", regex)
+            regex_box.config(state="disabled")
+            regex_box.pack(fill="x", padx=10)
+
+        if self.examples:
+            ttk.Label(self, text="Examples:").pack(anchor="w", padx=10, pady=(5, 0))
+            self.example_box = tk.Text(self, height=min(5, len(self.examples)), width=40)
+            self.example_box.pack(fill="x", padx=10)
+            self.example_box.config(state="disabled")
+
+        if isinstance(current, dict):
+            fmt = current.get("format", "none")
+            mapping_text = "\n".join(f"{k}={v}" for k, v in current.get("value_map", {}).items())
+            replace_pat = current.get("replace_pattern", "")
+            replace_with = current.get("replace_with", "")
+        else:
+            fmt = str(current)
+            mapping_text = ""
+            replace_pat = ""
+            replace_with = ""
 
         ttk.Label(self, text="Formatting:").pack(anchor="w", padx=10, pady=(10, 5))
-        self.var = tk.StringVar(value=current)
+        self.var = tk.StringVar(value=fmt)
         for value, label in self.TRANSFORMS:
             ttk.Radiobutton(self, text=label, variable=self.var, value=value).pack(anchor="w", padx=20)
+        self.var.trace_add("write", lambda *_: self._update_example_box())
+
+        ttk.Label(self, text="Value map (key=value per line):").pack(anchor="w", padx=10, pady=(10, 5))
+        self.map_text = tk.Text(self, height=4, width=40)
+        self.map_text.pack(fill="x", padx=10)
+        if mapping_text:
+            self.map_text.insert("1.0", mapping_text)
+        self.map_text.bind("<KeyRelease>", lambda e: self._update_example_box())
+
+        rep_frame = ttk.Frame(self)
+        rep_frame.pack(fill="x", padx=10, pady=5)
+        ttk.Label(rep_frame, text="Replace if pattern matches:").grid(row=0, column=0, sticky="w")
+        self.replace_pattern_var = tk.StringVar(value=replace_pat)
+        self.replace_with_var = tk.StringVar(value=replace_with)
+        ttk.Entry(rep_frame, textvariable=self.replace_pattern_var).grid(row=1, column=0, sticky="ew")
+        ttk.Entry(rep_frame, textvariable=self.replace_with_var).grid(row=1, column=1, sticky="ew")
+        self.replace_pattern_var.trace_add("write", lambda *_: self._update_example_box())
+        self.replace_with_var.trace_add("write", lambda *_: self._update_example_box())
+        rep_frame.grid_columnconfigure(0, weight=1)
+        rep_frame.grid_columnconfigure(1, weight=1)
 
         btns = ttk.Frame(self)
         btns.pack(pady=10)
         ttk.Button(btns, text="Save", command=self._on_save).pack(side="left", padx=5)
         ttk.Button(btns, text="Cancel", command=self.destroy).pack(side="left", padx=5)
 
+        # initial examples rendering
+        self._update_example_box()
+
+    @staticmethod
+    def _parse_mapping(text: str) -> dict:
+        mapping = {}
+        for line in text.strip().splitlines():
+            if '=' in line:
+                k, v = line.split('=', 1)
+                mapping[k.strip()] = v.strip()
+        return mapping
+
+    def _get_spec(self) -> object:
+        """Return the transformation spec from current UI values."""
+        fmt = self.var.get()
+        mapping = self._parse_mapping(self.map_text.get("1.0", "end"))
+        replace_pat = self.replace_pattern_var.get().strip()
+        replace_with = self.replace_with_var.get()
+
+        result = {"format": fmt}
+        if mapping:
+            result["value_map"] = mapping
+        if replace_pat:
+            result["replace_pattern"] = replace_pat
+            result["replace_with"] = replace_with
+
+        if list(result.keys()) == ["format"]:
+            return result["format"]
+        return result
+
+    def _update_example_box(self):
+        if not hasattr(self, "example_box"):
+            return
+        spec = self._get_spec()
+        self.example_box.config(state="normal")
+        self.example_box.delete("1.0", "end")
+        for ex in self.examples:
+            transformed = apply_transform(ex, spec)
+            self.example_box.insert("end", f"{ex} -> {transformed}\n")
+        self.example_box.config(state="disabled")
+
     def _on_save(self):
-        self.result = self.var.get()
+        result = self._get_spec()
+        self.result = result
         self.destroy()

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -55,3 +55,53 @@ def test_generate_files_constant_value(tmp_path):
     result = conv.convert_line('line')
     assert 'deviceVendor=ACME' in result
 
+
+def test_generate_files_advanced(tmp_path):
+    header = {
+        'CEF Version': '0',
+        'Device Vendor': 'ACME',
+        'Device Product': 'LP',
+        'Device Version': '1.0',
+        'Event Class ID': '42',
+        'Event Name': 'Test',
+        'Severity (int)': '5',
+    }
+    patterns = [
+        {'name': 'FullName', 'regex': r'full=(\w+) (\w+)'},
+        {'name': 'Severity', 'regex': r'sev=(\w+)'},
+        {'name': 'Status', 'regex': r'status=(\w+)'},
+    ]
+    mappings = [
+        {
+            'cef': 'suser',
+            'pattern': 'FullName',
+            'groups': [1, 2],
+            'transform': 'upper',
+        },
+        {
+            'cef': 'severity',
+            'pattern': 'Severity',
+            'group': 1,
+            'value_map': {'info': '1', 'error': '8'},
+            'transform': 'none',
+        },
+        {
+            'cef': 'app',
+            'pattern': 'Status',
+            'group': 1,
+            'replace_pattern': r'unknown',
+            'replace_with': 'UNKNOWN',
+            'transform': 'none',
+        },
+    ]
+
+    paths = generate_files(header, mappings, patterns, tmp_path)
+    loader = SourceFileLoader('cef_converter', paths[0])
+    module = loader.load_module()
+    conv = module.LogToCEFConverter()
+    line = 'full=john doe sev=error status=unknown'
+    result = conv.convert_line(line)
+    assert 'suser=JOHN DOE' in result
+    assert 'severity=8' in result
+    assert 'app=UNKNOWN' in result
+

--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -13,6 +13,13 @@ def test_find_example():
     assert dlg._find_example(r"error") == "error"
 
 
+def test_find_examples():
+    dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
+    dlg.logs = ["user=john", "user=jane", "something else"]
+    result = dlg._find_examples(r"user=(\w+)")
+    assert result == ["john", "jane"]
+
+
 def test_initial_mappings_duplicate(monkeypatch):
     dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
     dlg.per_log_patterns = [

--- a/tests/test_transform_editor.py
+++ b/tests/test_transform_editor.py
@@ -1,0 +1,43 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from gui.transform_editor import TransformEditorDialog
+
+
+def test_parse_mapping():
+    text = "info=1\nerror=8\n"
+    result = TransformEditorDialog._parse_mapping(text)
+    assert result == {'info': '1', 'error': '8'}
+
+
+class DummyVar:
+    def __init__(self, value):
+        self.value = value
+    def get(self):
+        return self.value
+    def set(self, v):
+        self.value = v
+
+
+class DummyText:
+    def __init__(self, text):
+        self.text = text
+    def get(self, start, end):
+        return self.text
+
+
+def test_get_spec():
+    dlg = TransformEditorDialog.__new__(TransformEditorDialog)
+    dlg.var = DummyVar('upper')
+    dlg.map_text = DummyText('info=1\nerror=8\n')
+    dlg.replace_pattern_var = DummyVar('foo')
+    dlg.replace_with_var = DummyVar('BAR')
+
+    spec = TransformEditorDialog._get_spec(dlg)
+    assert spec == {
+        'format': 'upper',
+        'value_map': {'info': '1', 'error': '8'},
+        'replace_pattern': 'foo',
+        'replace_with': 'BAR',
+    }

--- a/tests/test_transform_logic.py
+++ b/tests/test_transform_logic.py
@@ -12,3 +12,22 @@ def test_apply_transform_modes():
     assert apply_transform('john', 'capitalize') == 'John'
     assert apply_transform('hello WORLD', 'sentence') == 'Hello world'
     assert apply_transform('Same', 'none') == 'Same'
+
+
+def test_apply_transform_dict_map():
+    spec = {
+        'format': 'upper',
+        'value_map': {'info': '1', 'error': '8'},
+    }
+    assert apply_transform('info', spec) == '1'
+    assert apply_transform('error', spec) == '8'
+
+
+def test_apply_transform_dict_replace():
+    spec = {
+        'format': 'none',
+        'replace_pattern': r'foo',
+        'replace_with': 'BAR'
+    }
+    assert apply_transform('foo', spec) == 'BAR'
+    assert apply_transform('baz', spec) == 'baz'

--- a/utils/transform_logic.py
+++ b/utils/transform_logic.py
@@ -1,9 +1,12 @@
 """Simple transformation helpers for CEF field values."""
 
-from typing import Any
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
 
 
-def apply_transform(value: str, transform: str) -> str:
+def _apply_basic_transform(value: str, transform: str) -> str:
     """Apply a basic string transformation."""
     if value is None:
         value = ""
@@ -16,5 +19,22 @@ def apply_transform(value: str, transform: str) -> str:
     if transform == "sentence":
         return value[:1].upper() + value[1:].lower() if value else value
     return value
+
+
+def apply_transform(value: str, transform: Any) -> str:
+    """Apply a basic or advanced transformation."""
+    if isinstance(transform, dict):
+        fmt = transform.get("format", "none")
+        if transform.get("replace_pattern"):
+            pat = re.compile(transform["replace_pattern"])
+            if pat.fullmatch(value or ""):
+                value = transform.get("replace_with", "")
+        if transform.get("value_map"):
+            mapping: Dict[str, str] = transform["value_map"]
+            if value in mapping:
+                value = mapping[value]
+        return _apply_basic_transform(value, fmt)
+    return _apply_basic_transform(value, str(transform))
+
 
 


### PR DESCRIPTION
## Summary
- return unique matched segments instead of full lines
- update transform editor to show examples and their transformed values
- calculate transform spec dynamically in the editor
- test `_find_examples` with capture groups and new spec helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684242cdb76c832ba233f99428c04657