### PR TITLE
Enable substring mapping in transformations

### DIFF
--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -105,3 +105,27 @@ def test_generate_files_advanced(tmp_path):
     assert 'severity=8' in result
     assert 'app=UNKNOWN' in result
 
+
+def test_generate_files_value_map_substring(tmp_path):
+    header = {'CEF Version': '0'}
+    patterns = [
+        {'name': 'Msg', 'regex': r'msg=(.*)'}
+    ]
+    mappings = [
+        {
+            'cef': 'msg',
+            'pattern': 'Msg',
+            'group': 1,
+            'value_map': {'ERROR': '1', 'WARN': '2'},
+            'transform': 'none',
+        },
+    ]
+
+    paths = generate_files(header, mappings, patterns, tmp_path)
+    loader = SourceFileLoader('cef_converter', paths[0])
+    module = loader.load_module()
+    conv = module.LogToCEFConverter()
+    line = 'msg=Info: ERROR and more'
+    result = conv.convert_line(line)
+    assert 'msg=Info: 1 and more' in result
+

--- a/tests/test_transform_logic.py
+++ b/tests/test_transform_logic.py
@@ -23,6 +23,15 @@ def test_apply_transform_dict_map():
     assert apply_transform('error', spec) == '8'
 
 
+def test_apply_transform_dict_map_substring():
+    spec = {
+        'format': 'none',
+        'value_map': {'ERROR': '1', 'WARN': '2'},
+    }
+    assert apply_transform('Info: ERROR', spec) == 'Info: 1'
+    assert apply_transform('Detail WARN here', spec) == 'Detail 2 here'
+
+
 def test_apply_transform_dict_replace():
     spec = {
         'format': 'none',

--- a/utils/code_generator.py
+++ b/utils/code_generator.py
@@ -73,7 +73,13 @@ class LogToCEFConverter:
                 if re.fullmatch(m['replace_pattern'], value):
                     value = m.get('replace_with', '')
             if m.get('value_map'):
-                value = m['value_map'].get(value, value)
+                mapping = m['value_map']
+                if value in mapping:
+                    value = mapping[value]
+                else:
+                    for k, v in mapping.items():
+                        if k in value:
+                            value = value.replace(k, v)
 
             fields[m['cef']] = apply_transform(value, m.get('transform', 'none'))
         return self._build_cef_string(fields)

--- a/utils/transform_logic.py
+++ b/utils/transform_logic.py
@@ -33,6 +33,10 @@ def apply_transform(value: str, transform: Any) -> str:
             mapping: Dict[str, str] = transform["value_map"]
             if value in mapping:
                 value = mapping[value]
+            else:
+                for k, v in mapping.items():
+                    if k in (value or ""):
+                        value = (value or "").replace(k, v)
         return _apply_basic_transform(value, fmt)
     return _apply_basic_transform(value, str(transform))
 


### PR DESCRIPTION
## Summary
- support partial replacements in `apply_transform`
- extend code generation to use substring mapping
- add tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842557141a0832b9bc7f74a1d7f01e1