### PR TITLE
Fix token reorder editor not showing

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -203,6 +203,10 @@ class CodeGeneratorDialog(tk.Toplevel):
         pattern_map = {p["name"]: p for p in self._collect_patterns()}
         regex = pattern_map.get(m.get("pattern"), {}).get("regex", "")
         examples = self._find_examples(regex) if regex else []
+        if regex and not examples:
+            ex = self._find_example(regex)
+            if ex:
+                examples = [ex]
         dlg = TransformEditorDialog(self, m["cef"], current=m["transform"], regex=regex, examples=examples)
         dlg.grab_set()
         self.wait_window(dlg)

--- a/tests/test_transform_editor.py
+++ b/tests/test_transform_editor.py
@@ -32,6 +32,9 @@ def test_get_spec():
     dlg.map_text = DummyText('info=1\nerror=8\n')
     dlg.replace_pattern_var = DummyVar('foo')
     dlg.replace_with_var = DummyVar('BAR')
+    dlg.token_order = []
+    dlg.tokens = []
+    dlg.regex = ''
 
     spec = TransformEditorDialog._get_spec(dlg)
     assert spec == {
@@ -39,4 +42,22 @@ def test_get_spec():
         'value_map': {'info': '1', 'error': '8'},
         'replace_pattern': 'foo',
         'replace_with': 'BAR',
+    }
+
+
+def test_get_spec_token_order():
+    dlg = TransformEditorDialog.__new__(TransformEditorDialog)
+    dlg.var = DummyVar('lower')
+    dlg.map_text = DummyText('')
+    dlg.replace_pattern_var = DummyVar('')
+    dlg.replace_with_var = DummyVar('')
+    dlg.token_order = [1, 0]
+    dlg.tokens = ['a', 'b']
+    dlg.regex = r'(\w+) (\w+)'
+
+    spec = TransformEditorDialog._get_spec(dlg)
+    assert spec == {
+        'format': 'lower',
+        'token_order': [1, 0],
+        'regex': r'(\w+) (\w+)'
     }

--- a/tests/test_transform_logic.py
+++ b/tests/test_transform_logic.py
@@ -40,3 +40,12 @@ def test_apply_transform_dict_replace():
     }
     assert apply_transform('foo', spec) == 'BAR'
     assert apply_transform('baz', spec) == 'baz'
+
+
+def test_apply_transform_token_order():
+    spec = {
+        'format': 'none',
+        'regex': r'(\w+) (\w+) (\d+)',
+        'token_order': [2, 1, 0, 3, 4]
+    }
+    assert apply_transform('foo bar 123', spec) == 'bar foo 123'


### PR DESCRIPTION
## Summary
- ensure an example is provided when editing transforms
- always initialize token editor when a regex is present
- adjust token editor logic to search the first example only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842659bb1dc832bbb1031e3b9c77345