### PR TITLE
Update example extraction and add token editor test

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -131,7 +131,7 @@ class CodeGeneratorDialog(tk.Toplevel):
         return ""
 
     def _find_examples(self, regex: str, max_lines: int = 5) -> list[str]:
-        """Return unique captured segments for the regex."""
+        """Return unique matched segments for the regex."""
         import re
 
         try:
@@ -146,13 +146,7 @@ class CodeGeneratorDialog(tk.Toplevel):
             if not m:
                 continue
 
-            if m.lastindex:
-                if m.lastindex == 1:
-                    value = m.group(1)
-                else:
-                    value = " ".join(m.group(i) for i in range(1, m.lastindex + 1))
-            else:
-                value = m.group(0)
+            value = m.group(0)
 
             if value not in seen:
                 seen.add(value)

--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -17,7 +17,7 @@ def test_find_examples():
     dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
     dlg.logs = ["user=john", "user=jane", "something else"]
     result = dlg._find_examples(r"user=(\w+)")
-    assert result == ["john", "jane"]
+    assert result == ["user=john", "user=jane"]
 
 def test_initial_mappings_duplicate(monkeypatch):
     dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)

--- a/tests/test_transform_editor.py
+++ b/tests/test_transform_editor.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import tkinter as tk
+from tkinter import ttk
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from gui.transform_editor import TransformEditorDialog
@@ -61,3 +63,35 @@ def test_get_spec_token_order():
         'token_order': [1, 0],
         'regex': r'(\w+) (\w+)'
     }
+
+
+def test_init_token_editor_sets_tokens(monkeypatch):
+    dlg = TransformEditorDialog.__new__(TransformEditorDialog)
+    dlg.regex = r'user=(\w+)'
+    dlg.examples = ['user=jane']
+
+    # Avoid actual tkinter widgets
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+        def pack(self, *a, **k):
+            pass
+        def bind(self, *a, **k):
+            pass
+        def config(self, *a, **k):
+            pass
+        def yview(self, *a, **k):
+            pass
+        def set(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(ttk, 'Label', DummyWidget)
+    monkeypatch.setattr(ttk, 'Frame', DummyWidget)
+    monkeypatch.setattr(tk, 'Listbox', DummyWidget)
+    monkeypatch.setattr(ttk, 'Scrollbar', DummyWidget)
+    monkeypatch.setattr(TransformEditorDialog, '_refresh_token_list', lambda self: None)
+
+    TransformEditorDialog._init_token_editor(dlg)
+
+    assert dlg.tokens == ['user=', 'jane']
+    assert dlg.token_order == [0, 1]


### PR DESCRIPTION
## Summary
- return full regex matches in `_find_examples`
- update dialog test expectations
- test that `_init_token_editor` extracts tokens correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68426e360df8832ba0b3acb336c17c02