### PR TITLE
Fix example display and token editor matching

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -201,7 +201,14 @@ class CodeGeneratorDialog(tk.Toplevel):
             ex = self._find_example(regex)
             if ex:
                 examples = [ex]
-        dlg = TransformEditorDialog(self, m["cef"], current=m["transform"], regex=regex, examples=examples)
+        dlg = TransformEditorDialog(
+            self,
+            m["cef"],
+            current=m["transform"],
+            regex=regex,
+            examples=examples,
+            logs=self.logs,
+        )
         dlg.grab_set()
         self.wait_window(dlg)
         if dlg.result is not None:

--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -15,12 +15,13 @@ class TransformEditorDialog(tk.Toplevel):
         ("sentence", "Sentence case"),
     ]
 
-    def __init__(self, parent, cef_field: str, current: object = "none", *, regex: str = "", examples: list[str] | None = None):
+    def __init__(self, parent, cef_field: str, current: object = "none", *, regex: str = "", examples: list[str] | None = None, logs: list[str] | None = None):
         super().__init__(parent)
         self.result = None
         self.title(f"Transform Editor for CEF Field: {cef_field}")
         self.minsize(300, 360)
         self.examples = examples or []
+        self.logs = logs or []
         self.regex = regex
         self.tokens = []
         self.token_order = []
@@ -90,14 +91,21 @@ class TransformEditorDialog(tk.Toplevel):
         import re
 
         pat = re.compile(self.regex)
-        value = None
-        for ex in self.examples:
-            m = pat.search(ex)
-            if m:
-                value = ex
-                break
-        if value is None:
+        best = None
+        search_space = getattr(self, "logs", []) or self.examples
+        for line in search_space:
+            m = pat.search(line)
+            if not m:
+                continue
+            # choose the match with the most groups/longest span
+            if best is None or (m.lastindex or 0) > (best[0].lastindex or 0) or (
+                (m.lastindex or 0) == (best[0].lastindex or 0) and m.end() - m.start() > best[0].end() - best[0].start()
+            ):
+                best = (m, line)
+        if best is None:
             return
+        m, line = best
+        value = line
 
         tokens = []
         pos = m.start()


### PR DESCRIPTION
## Summary
- revert example search to return regex matches only
- search original logs for token reorder matches
- inject logs into transform editor from code generator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842738ec7ec832ba69f3426974b7652