### PR TITLE
Enable drag-drop token editor

### DIFF
--- a/tests/test_transform_editor.py
+++ b/tests/test_transform_editor.py
@@ -2,7 +2,8 @@ import sys
 import os
 import tkinter as tk
 from tkinter import ttk
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from gui.transform_editor import TransformEditorDialog
 
@@ -10,13 +11,16 @@ from gui.transform_editor import TransformEditorDialog
 def test_parse_mapping():
     text = "info=1\nerror=8\n"
     result = TransformEditorDialog._parse_mapping(text)
-    assert result == {'info': '1', 'error': '8'}
+    assert result == {"info": "1", "error": "8"}
+
 
 class DummyVar:
     def __init__(self, value):
         self.value = value
+
     def get(self):
         return self.value
+
     def set(self, v):
         self.value = v
 
@@ -24,75 +28,101 @@ class DummyVar:
 class DummyText:
     def __init__(self, text):
         self.text = text
+
     def get(self, start, end):
         return self.text
 
 
 def test_get_spec():
     dlg = TransformEditorDialog.__new__(TransformEditorDialog)
-    dlg.var = DummyVar('upper')
-    dlg.map_text = DummyText('info=1\nerror=8\n')
-    dlg.replace_pattern_var = DummyVar('foo')
-    dlg.replace_with_var = DummyVar('BAR')
+    dlg.var = DummyVar("upper")
+    dlg.map_text = DummyText("info=1\nerror=8\n")
+    dlg.replace_pattern_var = DummyVar("foo")
+    dlg.replace_with_var = DummyVar("BAR")
     dlg.token_order = []
     dlg.tokens = []
-    dlg.regex = ''
+    dlg.regex = ""
 
     spec = TransformEditorDialog._get_spec(dlg)
     assert spec == {
-        'format': 'upper',
-        'value_map': {'info': '1', 'error': '8'},
-        'replace_pattern': 'foo',
-        'replace_with': 'BAR',
+        "format": "upper",
+        "value_map": {"info": "1", "error": "8"},
+        "replace_pattern": "foo",
+        "replace_with": "BAR",
     }
 
 
 def test_get_spec_token_order():
     dlg = TransformEditorDialog.__new__(TransformEditorDialog)
-    dlg.var = DummyVar('lower')
-    dlg.map_text = DummyText('')
-    dlg.replace_pattern_var = DummyVar('')
-    dlg.replace_with_var = DummyVar('')
+    dlg.var = DummyVar("lower")
+    dlg.map_text = DummyText("")
+    dlg.replace_pattern_var = DummyVar("")
+    dlg.replace_with_var = DummyVar("")
     dlg.token_order = [1, 0]
-    dlg.tokens = ['a', 'b']
-    dlg.regex = r'(\w+) (\w+)'
+    dlg.tokens = ["a", "b"]
+    dlg.regex = r"(\w+) (\w+)"
 
     spec = TransformEditorDialog._get_spec(dlg)
-    assert spec == {
-        'format': 'lower',
-        'token_order': [1, 0],
-        'regex': r'(\w+) (\w+)'
-    }
+    assert spec == {"format": "lower", "token_order": [1, 0], "regex": r"(\w+) (\w+)"}
 
 
 def test_init_token_editor_sets_tokens(monkeypatch):
     dlg = TransformEditorDialog.__new__(TransformEditorDialog)
-    dlg.regex = r'user=(\w+)'
-    dlg.examples = ['user=jane']
+    dlg.regex = r"user=(\w+)"
+    dlg.examples = ["user=jane"]
 
     # Avoid actual tkinter widgets
     class DummyWidget:
         def __init__(self, *a, **k):
             pass
+
         def pack(self, *a, **k):
             pass
+
         def bind(self, *a, **k):
             pass
+
         def config(self, *a, **k):
             pass
+
         def yview(self, *a, **k):
             pass
+
         def set(self, *a, **k):
             pass
 
-    monkeypatch.setattr(ttk, 'Label', DummyWidget)
-    monkeypatch.setattr(ttk, 'Frame', DummyWidget)
-    monkeypatch.setattr(ttk, 'LabelFrame', DummyWidget)
-    monkeypatch.setattr(tk, 'Listbox', DummyWidget)
-    monkeypatch.setattr(ttk, 'Scrollbar', DummyWidget)
-    monkeypatch.setattr(TransformEditorDialog, '_refresh_token_list', lambda self: None)
+    monkeypatch.setattr(ttk, "Label", DummyWidget)
+    monkeypatch.setattr(ttk, "Frame", DummyWidget)
+    monkeypatch.setattr(ttk, "LabelFrame", DummyWidget)
+    monkeypatch.setattr(TransformEditorDialog, "_refresh_token_list", lambda self: None)
 
     TransformEditorDialog._init_token_editor(dlg)
 
-    assert dlg.tokens == ['user=', 'jane']
+    assert dlg.tokens == ["user=", "jane"]
     assert dlg.token_order == [0, 1]
+
+
+def test_init_token_editor_split_on_no_groups(monkeypatch):
+    dlg = TransformEditorDialog.__new__(TransformEditorDialog)
+    dlg.regex = r"\d{2}/\d{2}/\d{4}"
+    dlg.examples = ["01/02/2024"]
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def bind(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(ttk, "Label", DummyWidget)
+    monkeypatch.setattr(ttk, "Frame", DummyWidget)
+    monkeypatch.setattr(ttk, "LabelFrame", DummyWidget)
+    monkeypatch.setattr(TransformEditorDialog, "_refresh_token_list", lambda self: None)
+
+    TransformEditorDialog._init_token_editor(dlg)
+
+    assert dlg.tokens == ["01", "/", "02", "/", "2024"]
+    assert dlg.token_order == [0, 1, 2, 3, 4]

--- a/tests/test_transform_logic.py
+++ b/tests/test_transform_logic.py
@@ -49,3 +49,12 @@ def test_apply_transform_token_order():
         'token_order': [2, 1, 0, 3, 4]
     }
     assert apply_transform('foo bar 123', spec) == 'bar foo 123'
+
+
+def test_reorder_tokens_no_groups():
+    spec = {
+        'format': 'none',
+        'regex': r'\d{2}/\d{2}/\d{4}',
+        'token_order': [4, 3, 2, 1, 0]
+    }
+    assert apply_transform('01/02/2024', spec) == '2024/02/01'

--- a/utils/transform_logic.py
+++ b/utils/transform_logic.py
@@ -32,16 +32,20 @@ def _reorder_tokens(value: str, regex: str, order: List[int]) -> str:
     if not m:
         return value
     tokens: List[str] = []
-    pos = m.start()
-    for i in range(1, (m.lastindex or 0) + 1):
-        literal = value[pos:m.start(i)]
-        if literal:
-            tokens.append(literal)
-        tokens.append(m.group(i))
-        pos = m.end(i)
-    tail = value[pos:m.end()]
-    if tail:
-        tokens.append(tail)
+    if m.lastindex:
+        pos = m.start()
+        for i in range(1, (m.lastindex or 0) + 1):
+            literal = value[pos:m.start(i)]
+            if literal:
+                tokens.append(literal)
+            tokens.append(m.group(i))
+            pos = m.end(i)
+        tail = value[pos:m.end()]
+        if tail:
+            tokens.append(tail)
+    else:
+        span = value[m.start():m.end()]
+        tokens = [t for t in re.split(r"([a-zA-Z]+|\d+|\W)", span) if t]
     return "".join(tokens[i] for i in order if i < len(tokens))
 
 


### PR DESCRIPTION
## Summary
- replace Listbox with draggable token widgets in TransformEditorDialog
- adjust tests to handle new token editor implementation
- handle tokenization when regex lacks capturing groups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427c653128832ba76717f25cf95f17