### PR TITLE
Update token drag behavior to refresh examples

### DIFF
--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -230,6 +230,7 @@ class TransformEditorDialog(tk.Toplevel):
             for widget in self.token_widgets:
                 widget.pack_forget()
                 widget.pack(side="left", padx=2, pady=2)
+            self._update_example_box()
 
     def _on_drag_stop(self, event):
         self._drag_widget = None

--- a/tests/test_transform_editor.py
+++ b/tests/test_transform_editor.py
@@ -198,3 +198,43 @@ def test_drag_updates_token_order(monkeypatch):
     dlg._on_drag_stop(DummyEvent(widget=dlg.token_widgets[0]))
 
     assert dlg.token_order == [1, 2, 0]
+
+
+def test_drag_updates_example(monkeypatch):
+    dlg = TransformEditorDialog.__new__(TransformEditorDialog)
+
+    class DummyFrame:
+        def winfo_rootx(self):
+            return 0
+
+    class DummyLabel:
+        def __init__(self, idx):
+            self.token_idx = idx
+            self._x = idx * 10
+        def winfo_x(self):
+            return self._x
+        def winfo_width(self):
+            return 8
+        def pack_forget(self, *a, **k):
+            pass
+        def pack(self, *a, **k):
+            pass
+
+    dlg.token_frame = DummyFrame()
+    dlg.token_widgets = [DummyLabel(0), DummyLabel(1), DummyLabel(2)]
+    dlg.token_order = [0, 1, 2]
+
+    called = {}
+    def fake_update():
+        called['hit'] = True
+    dlg._update_example_box = fake_update
+
+    class DummyEvent:
+        def __init__(self, widget=None, x_root=0):
+            self.widget = widget
+            self.x_root = x_root
+
+    dlg._on_drag_start(DummyEvent(widget=dlg.token_widgets[0]))
+    dlg._on_drag_motion(DummyEvent(widget=dlg.token_widgets[0], x_root=50))
+
+    assert called.get('hit')


### PR DESCRIPTION
## Summary
- refresh example text while dragging tokens in TransformEditor
- test that token drag calls the example update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429711367c832baba79aa7345a1a2b