### PR TITLE
Package modules and add lookahead reorder test

### DIFF
--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -230,6 +230,7 @@ class TransformEditorDialog(tk.Toplevel):
             for widget in self.token_widgets:
                 widget.pack_forget()
                 widget.pack(side="left", padx=2, pady=2)
+            self._update_example_box()
 
     def _on_drag_stop(self, event):
         self._drag_widget = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -1,8 +1,5 @@
 import os
-import sys
 from importlib.machinery import SourceFileLoader
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from utils.code_generator import generate_files
 

--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -1,7 +1,3 @@
-import os
-import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from gui.code_generator_dialog import CodeGeneratorDialog
 from utils import json_utils
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,7 +1,4 @@
-import os
-import sys
 from typing import List, Dict
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from utils.text_utils import compute_char_coverage
 

--- a/tests/test_enum_regex_generator.py
+++ b/tests/test_enum_regex_generator.py
@@ -1,11 +1,7 @@
-import sys
-import os
 import re
 import pytest
 from typing import List
 
-# Добавляем core/ в PYTHONPATH
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from core.regex.enum_generator import EnumRegexGenerator
 

--- a/tests/test_generalizer.py
+++ b/tests/test_generalizer.py
@@ -1,10 +1,5 @@
-import sys
-import os
 import re
 import pytest
-
-# Добавим путь к корню проекта, чтобы core был виден
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from core.regex.generalizer import generalize_token
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,9 +1,5 @@
-import sys
-import os
 import types
 import tkinter as tk
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from gui.app_window import AppWindow
 from gui.pattern_panel import PatternPanel

--- a/tests/test_log_key_mapping.py
+++ b/tests/test_log_key_mapping.py
@@ -1,8 +1,5 @@
 import json
-import os
-import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from utils import json_utils
 

--- a/tests/test_match_selection.py
+++ b/tests/test_match_selection.py
@@ -1,6 +1,3 @@
-import os, sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from core.regex_highlighter import compute_optimal_matches
 
 

--- a/tests/test_open_code_generator.py
+++ b/tests/test_open_code_generator.py
@@ -1,8 +1,3 @@
-import os
-import sys
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from gui.app_window import AppWindow
 from utils import json_utils
 

--- a/tests/test_pattern_wizard.py
+++ b/tests/test_pattern_wizard.py
@@ -1,8 +1,3 @@
-import os
-import sys
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 import tkinter as tk
 from tkinter import ttk
 

--- a/tests/test_per_log_patterns.py
+++ b/tests/test_per_log_patterns.py
@@ -1,8 +1,5 @@
 import json
-import os
-import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from utils import json_utils
 from gui.app_window import AppWindow

--- a/tests/test_regex_builder.py
+++ b/tests/test_regex_builder.py
@@ -1,9 +1,4 @@
 import re
-import os
-import sys
-
-# Ensure the core package is importable when running tests directly
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from core.regex.regex_builder import build_draft_regex_from_examples
 

--- a/tests/test_regex_highlighter.py
+++ b/tests/test_regex_highlighter.py
@@ -1,7 +1,3 @@
-import os
-import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from core.regex_highlighter import compute_optimal_matches
 
 

--- a/tests/test_save_per_log_pattern.py
+++ b/tests/test_save_per_log_pattern.py
@@ -1,8 +1,5 @@
 import json
-import os
-import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from utils import json_utils
 

--- a/tests/test_transform_logic.py
+++ b/tests/test_transform_logic.py
@@ -1,8 +1,3 @@
-import sys
-import os
-
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 from utils.transform_logic import apply_transform
 
 
@@ -58,3 +53,49 @@ def test_reorder_tokens_no_groups():
         'token_order': [4, 3, 2, 1, 0]
     }
     assert apply_transform('01/02/2024', spec) == '2024/02/01'
+
+
+def test_apply_transform_complex_reorder():
+    spec = {
+        'format': 'none',
+        'regex': r'[a-zA-Z]+ {1,2}\d{1,2}\ \d{2}:\d{2}:\d{2}',
+        'token_order': [2, 3, 4, 5, 6, 7, 8, 1, 0]
+    }
+    examples = [
+        'Jun 14 15:16:01',
+        'Jun 14 15:16:02',
+        'Jun 15 02:04:59',
+        'Jun 15 04:06:18',
+        'Jun 15 04:06:19',
+    ]
+    results = [apply_transform(e, spec) for e in examples]
+    assert results == [
+        '14 15:16:01 Jun',
+        '14 15:16:02 Jun',
+        '15 02:04:59 Jun',
+        '15 04:06:18 Jun',
+        '15 04:06:19 Jun',
+    ]
+
+
+def test_apply_transform_lookahead_reorder():
+    spec = {
+        'format': 'none',
+        'regex': r'[a-zA-Z]+ {1,2}\d{1,2}\ \d{2}:\d{2}:\d{2}(?= combo)',
+        'token_order': [2, 3, 4, 5, 6, 7, 8, 1, 0],
+    }
+    examples = [
+        'Jun 14 15:16:01 combo',
+        'Jun 14 15:16:02 combo',
+        'Jun 15 02:04:59 combo',
+        'Jun 15 04:06:18 combo',
+        'Jun 15 04:06:19 combo',
+    ]
+    results = [apply_transform(e, spec) for e in examples]
+    assert results == [
+        '14 15:16:01 Jun',
+        '14 15:16:02 Jun',
+        '15 02:04:59 Jun',
+        '15 04:06:18 Jun',
+        '15 04:06:19 Jun',
+    ]

--- a/tests/test_utils_extended.py
+++ b/tests/test_utils_extended.py
@@ -1,11 +1,8 @@
-import os
-import sys
 import json
 import re
 import math
 import tempfile
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from utils import json_utils, color_utils, text_utils
 from core.tokenizer.tree_tokenizer import build_token_tree, flatten_token_tree


### PR DESCRIPTION
## Summary
- make `utils` and `gui` real packages
- clean up tests to import modules directly
- centralize path setup in `tests/conftest.py`
- cover token reordering with regex look‑ahead

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429711367c832baba79aa7345a1a2b