### PR TITLE
Show regex context in transform examples

### DIFF
--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -304,9 +304,40 @@ class TransformEditorDialog(tk.Toplevel):
         spec = self._get_spec()
         self.example_box.config(state="normal")
         self.example_box.delete("1.0", "end")
+        if self.regex:
+            import re
+
+            try:
+                pat = re.compile(self.regex)
+            except re.error:
+                pat = None
+        else:
+            pat = None
+
+        self.example_box.tag_configure("context", foreground="gray")
+
         for ex in self.examples:
             transformed = apply_transform(ex, spec)
-            self.example_box.insert("end", f"{ex} -> {transformed}\n")
+
+            prefix = ""
+            suffix = ""
+            if pat and self.logs:
+                for line in self.logs:
+                    m = pat.search(line)
+                    if m and m.group(0) == ex:
+                        prefix = line[: m.start()]
+                        suffix = line[m.end() :]
+                        break
+
+            if prefix:
+                self.example_box.insert("end", prefix, "context")
+            self.example_box.insert("end", ex)
+            if suffix:
+                self.example_box.insert("end", suffix, "context")
+            self.example_box.insert("end", " -> ")
+            self.example_box.insert("end", transformed)
+            self.example_box.insert("end", "\n")
+
         self.example_box.config(state="disabled")
 
     def _on_save(self):

--- a/tests/test_transform_editor.py
+++ b/tests/test_transform_editor.py
@@ -235,3 +235,38 @@ def test_drag_updates_example(monkeypatch):
     dlg._on_drag_motion(DummyEvent(widget=dlg.token_widgets[0], x_root=50))
 
     assert called.get('hit')
+
+
+def test_update_example_box_shows_context(monkeypatch):
+    dlg = TransformEditorDialog.__new__(TransformEditorDialog)
+
+    dlg.regex = r"[a-zA-Z]+ {1,2}\d{1,2}\ \d{2}:\d{2}:\d{2}(?= combo)"
+    dlg.examples = ["Jun 14 15:16:01"]
+    dlg.logs = ["Jun 14 15:16:01 combo"]
+    dlg.var = DummyVar("none")
+    dlg.map_text = DummyText("")
+    dlg.replace_pattern_var = DummyVar("")
+    dlg.replace_with_var = DummyVar("")
+    dlg.token_order = []
+    dlg.tokens = []
+
+    actions = []
+
+    class DummyBox:
+        def config(self, **k):
+            actions.append(("config", k))
+
+        def delete(self, *a):
+            actions.append(("delete", a))
+
+        def insert(self, index, text, tag=None):
+            actions.append(("insert", text, tag))
+
+        def tag_configure(self, tag, **opts):
+            actions.append(("tag", tag, opts))
+
+    dlg.example_box = DummyBox()
+
+    TransformEditorDialog._update_example_box(dlg)
+
+    assert ("insert", " combo", "context") in actions


### PR DESCRIPTION
## Summary
- enhance `TransformEditorDialog` to display prefix/suffix context for examples
- highlight context text in grey so look‑ahead/behind portions are visible
- test example box context display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c12ee424832bb5faf0204c455e68