### PR TITLE
Fix transform examples context handling

### DIFF
--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -317,17 +317,19 @@ class TransformEditorDialog(tk.Toplevel):
         self.example_box.tag_configure("context", foreground="gray")
 
         for ex in self.examples:
-            transformed = apply_transform(ex, spec)
-
             prefix = ""
             suffix = ""
+            line = ex
             if pat and self.logs:
-                for line in self.logs:
-                    m = pat.search(line)
+                for line_text in self.logs:
+                    m = pat.search(line_text)
                     if m and m.group(0) == ex:
-                        prefix = line[: m.start()]
-                        suffix = line[m.end() :]
+                        prefix = line_text[: m.start()]
+                        suffix = line_text[m.end() :]
+                        line = line_text
                         break
+
+            transformed = apply_transform(line, spec)
 
             if prefix:
                 self.example_box.insert("end", prefix, "context")

--- a/tests/test_transform_editor.py
+++ b/tests/test_transform_editor.py
@@ -270,3 +270,38 @@ def test_update_example_box_shows_context(monkeypatch):
     TransformEditorDialog._update_example_box(dlg)
 
     assert ("insert", " combo", "context") in actions
+
+
+def test_update_example_box_reorders_with_lookahead(monkeypatch):
+    dlg = TransformEditorDialog.__new__(TransformEditorDialog)
+
+    dlg.regex = r"[a-zA-Z]+ {1,2}\d{1,2}\ \d{2}:\d{2}:\d{2}(?= combo)"
+    dlg.examples = ["Jun 14 15:16:01"]
+    dlg.logs = ["Jun 14 15:16:01 combo"]
+    dlg.var = DummyVar("none")
+    dlg.map_text = DummyText("")
+    dlg.replace_pattern_var = DummyVar("")
+    dlg.replace_with_var = DummyVar("")
+    dlg.token_order = [2, 3, 4, 5, 6, 7, 8, 1, 0]
+    dlg.tokens = list(range(9))
+
+    actions = []
+
+    class DummyBox:
+        def config(self, **k):
+            actions.append(("config", k))
+
+        def delete(self, *a):
+            actions.append(("delete", a))
+
+        def insert(self, index, text, tag=None):
+            actions.append(("insert", text, tag))
+
+        def tag_configure(self, tag, **opts):
+            actions.append(("tag", tag, opts))
+
+    dlg.example_box = DummyBox()
+
+    TransformEditorDialog._update_example_box(dlg)
+
+    assert ("insert", "14 15:16:01 Jun", None) in actions


### PR DESCRIPTION
## Summary
- apply transformations to the whole log line when computing examples
- maintain example display formatting while using transformed result from the full line
- test that look-ahead regex examples reorder tokens properly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d2659470832b98d3a9241cbdd52f