### PR TITLE
Fix undefined variable in transform editor

### DIFF
--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -329,18 +329,18 @@ class TransformEditorDialog(tk.Toplevel):
                         line = line_text
                         break
 
-            transformed_part = apply_transform(line, spec)
+            transformed_line = apply_transform(line, spec)
 
             if prefix:
                 self.example_box.insert("end", prefix, "context")
             self.example_box.insert("end", ex)
             self.example_box.insert("end", " -> ")
-            self.example_box.insert("end", transformed_part)
+            self.example_box.insert("end", transformed_line)
             if suffix:
                 self.example_box.insert("end", suffix, "context")
 
             self.example_box.insert("end", " -> ")
-            self.example_box.insert("end", transformed_part)
+            self.example_box.insert("end", transformed_line)
             self.example_box.insert("end", "\n")
 
         self.example_box.config(state="disabled")


### PR DESCRIPTION
## Summary
- rename `transformed_part` to `transformed_line` in `TransformEditorDialog`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843571c4da0832b9873b9454098212f