### PR TITLE
Simplify transform example display

### DIFF
--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -331,14 +331,9 @@ class TransformEditorDialog(tk.Toplevel):
 
             transformed_line = apply_transform(line, spec)
 
-            if prefix:
-                self.example_box.insert("end", prefix, "context")
+            # Only show the example before and after transformation.
+            # Skip any surrounding log context for a cleaner display.
             self.example_box.insert("end", ex)
-            self.example_box.insert("end", " -> ")
-            self.example_box.insert("end", transformed_line)
-            if suffix:
-                self.example_box.insert("end", suffix, "context")
-
             self.example_box.insert("end", " -> ")
             self.example_box.insert("end", transformed_line)
             self.example_box.insert("end", "\n")

--- a/tests/test_transform_editor.py
+++ b/tests/test_transform_editor.py
@@ -269,7 +269,8 @@ def test_update_example_box_shows_context(monkeypatch):
 
     TransformEditorDialog._update_example_box(dlg)
 
-    assert ("insert", " combo", "context") in actions
+    # No context should be displayed in the example output
+    assert ("insert", " combo", "context") not in actions
 
 
 def test_update_example_box_reorders_with_lookahead(monkeypatch):
@@ -338,5 +339,6 @@ def test_update_example_box_formats_example_only(monkeypatch):
 
     TransformEditorDialog._update_example_box(dlg)
 
-    assert ("insert", " bar", "context") in actions
+    # Context text should not be inserted in the new display
+    assert ("insert", " bar", "context") not in actions
     assert ("insert", "FOO BAR", None) in actions


### PR DESCRIPTION
## Summary
- show only example before/after transform in Transform Editor
- update tests for new example display

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435997191c832b8ce6e38382873d8d