### PR TITLE
Support incremental signatureID rule

### DIFF
--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -130,3 +130,27 @@ def test_generate_files_value_map_substring(tmp_path):
     result = conv.convert_line(line)
     assert 'msg=Info: 1 and more' in result
 
+
+def test_generate_files_incremental_rule(tmp_path):
+    header = {'CEF Version': '0'}
+    patterns = []
+    mappings = [
+        {
+            'cef': 'signatureID',
+            'rule': 'incremental',
+            'transform': 'none',
+        },
+    ]
+
+    paths = generate_files(header, mappings, patterns, tmp_path)
+    spec = importlib.util.spec_from_file_location('cef_converter', paths[0])
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    conv = module.LogToCEFConverter()
+    r1 = conv.convert_line('l1')
+    r2 = conv.convert_line('l2')
+    r3 = conv.convert_line('l3')
+    assert 'signatureID=0' in r1
+    assert 'signatureID=1' in r2
+    assert 'signatureID=2' in r3
+

--- a/utils/code_generator.py
+++ b/utils/code_generator.py
@@ -25,6 +25,7 @@ def generate_files(header: Dict[str, str], mappings: List[Dict], patterns: List[
         - 'value_map': mapping of values
         - 'replace_pattern': regex for replacement check
         - 'replace_with': replacement value
+        - 'rule': special rule like 'incremental'
     patterns : list of dict
         Available patterns with 'name' and 'regex'.
     output_dir : str
@@ -51,12 +52,16 @@ class LogToCEFConverter:
         self.compiled_patterns = {pattern_repr}
         self.mappings = {mapping_repr}
         self.cef_header = {header_repr}
+        self._sig_counter = -1
 
     def convert_line(self, line: str) -> str:
         matches = {{name: rgx.search(line) for name, rgx in self.compiled_patterns.items()}}
         fields = {{}}
         for m in self.mappings:
-            if m.get('pattern'):
+            if m.get('rule') == 'incremental':
+                self._sig_counter += 1
+                value = str(self._sig_counter)
+            elif m.get('pattern'):
                 match = matches.get(m['pattern'])
                 if match:
                     if 'groups' in m:


### PR DESCRIPTION
## Summary
- support `rule: incremental` mappings in generated converters
- generate converter code that increments `signatureID`
- test that the new rule increments `signatureID`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843808be8fc832b9b00898009c603b5