### PR TITLE
Add time transform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ pytest -q
 
 Make sure you have the required dependencies installed before running
 the tests.
+
+## Transformations
+
+When configuring mappings, several value transformations are available:
+
+- `lower`, `upper`, `capitalize`, `sentence`
+- `time` &mdash; automatically detects common date/time formats using
+  `python-dateutil` and converts them to `YYYY-MM-DDTHH:MM:SSZ`.
+
+Mappings created automatically for CEF fields of the `Time` category
+use this transformation by default.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 matplotlib
+python-dateutil

--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -79,3 +79,20 @@ def test_get_transformed_example_constant():
     result = CodeGeneratorDialog._get_transformed_example(dlg, "", "lower", value="ACME")
     assert result == "acme"
 
+
+def test_initial_mappings_time_transform(monkeypatch):
+    dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
+
+    patterns = [
+        {"name": "TimePat", "regex": "foo", "fields": ["rt"]},
+    ]
+
+    dlg.per_log_patterns = patterns
+    monkeypatch.setattr(CodeGeneratorDialog, "_collect_patterns", lambda self: patterns)
+    monkeypatch.setattr(json_utils, "load_cef_field_keys", lambda: ["rt"])
+    monkeypatch.setattr(json_utils, "load_cef_fields", lambda: [{"key": "rt", "category": "Time"}])
+
+    mappings = CodeGeneratorDialog._build_initial_mappings(dlg)
+    tran = [m["transform"] for m in mappings if m["cef"] == "rt"]
+    assert tran == ["time"]
+

--- a/tests/test_transform_logic.py
+++ b/tests/test_transform_logic.py
@@ -99,3 +99,16 @@ def test_apply_transform_lookahead_reorder():
         '15 04:06:18 Jun',
         '15 04:06:19 Jun',
     ]
+
+
+def test_apply_transform_time_iso():
+    assert apply_transform('2024-06-02T12:34:56Z', 'time') == '2024-06-02T12:34:56Z'
+
+
+def test_apply_transform_time_space():
+    assert apply_transform('2024-06-02 12:34:56', 'time') == '2024-06-02T12:34:56Z'
+
+
+def test_apply_transform_time_various_formats():
+    assert apply_transform('Jun 02, 2024 12:34:56', 'time') == '2024-06-02T12:34:56Z'
+    assert apply_transform('02/06/2024 12:34:56 +0300', 'time') == '2024-06-02T09:34:56Z'

--- a/utils/transform_logic.py
+++ b/utils/transform_logic.py
@@ -3,7 +3,27 @@
 from __future__ import annotations
 
 import re
+from datetime import timezone
+from dateutil import parser as date_parser
 from typing import Any, Dict, List
+
+
+def _normalize_time(value: str) -> str:
+    """Parse an arbitrary date string and return ISO-8601 in UTC."""
+    if not value:
+        return value
+    try:
+        if '/' in value:
+            dt = date_parser.parse(value, dayfirst=True)
+        else:
+            dt = date_parser.parse(value)
+    except (ValueError, TypeError):
+        return value
+    if not dt.tzinfo:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _apply_basic_transform(value: str, transform: str) -> str:
@@ -19,6 +39,8 @@ def _apply_basic_transform(value: str, transform: str) -> str:
         return value.title()
     if transform == "sentence":
         return value[:1].upper() + value[1:].lower() if value else value
+    if transform == "time":
+        return _normalize_time(value)
     return value
 
 


### PR DESCRIPTION
## Summary
- support new `time` transform for common date formats
- warn user when editing transforms for time fields
- auto-add `time` transform in initial mappings for time fields
- document available transforms
- test new behavior
- parse arbitrary time formats via python-dateutil

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843815df484832ba467d340c0661d97