### PR TITLE
Add save button to code generator dialog

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -67,6 +67,7 @@ class CodeGeneratorDialog(tk.Toplevel):
         btns = ttk.Frame(self)
         btns.pack(fill="x", pady=5)
         ttk.Button(btns, text="+ Add Field", command=self._on_add_field).pack(side="left", padx=5)
+        ttk.Button(btns, text="Save Config", command=self._save_config).pack(side="right", padx=5)
         ttk.Button(btns, text="Preview Code ▸", command=self._on_preview).pack(side="right", padx=5)
         ttk.Button(btns, text="Generate Python", command=self._on_generate).pack(side="right", padx=5)
 


### PR DESCRIPTION
## Summary
- add explicit 'Save Config' button in the code generator dialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684386727610832b8579cd3191f2b67d