### PR TITLE
Add per-log conversion config support

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -320,7 +320,10 @@ class AppWindow(tk.Frame):
                     if key:
                         per_patterns = load_per_log_patterns_by_key(key)
 
-            dlg = CodeGeneratorDialog(self, per_log_patterns=per_patterns, logs=self.logs)
+            log_key = None
+            if getattr(self, "source_path", None):
+                log_key = get_log_name_for_file(self.source_path)
+            dlg = CodeGeneratorDialog(self, per_log_patterns=per_patterns, logs=self.logs, log_key=log_key)
             dlg.grab_set()
         except Exception as e:
             logger.error("[CodeGenerator] %s", e)

--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -20,14 +20,15 @@ class CodeGeneratorDialog(tk.Toplevel):
         "severity",
     ]
 
-    def __init__(self, parent, per_log_patterns=None, logs=None):
+    def __init__(self, parent, per_log_patterns=None, logs=None, log_key=None):
         super().__init__(parent)
         self.title("CEF Code Generator Dialog")
         self.minsize(700, 500)
         self.per_log_patterns = per_log_patterns or []
         self.logs = logs or []
+        self.log_key = log_key
 
-        config = json_utils.load_conversion_config()
+        config = json_utils.load_conversion_config(log_key)
         self.mappings = config.get("mappings") or self._build_initial_mappings()
         self._build_ui()
         header_data = config.get("header", {})
@@ -338,7 +339,7 @@ class CodeGeneratorDialog(tk.Toplevel):
     def _save_config(self):
         header = {k: v.get() for k, v in self.header_vars.items()}
         data = {"header": header, "mappings": self.mappings}
-        json_utils.save_conversion_config(data)
+        json_utils.save_conversion_config(data, self.log_key)
 
     def _on_close(self):
         self._save_config()

--- a/tests/test_conversion_config.py
+++ b/tests/test_conversion_config.py
@@ -7,7 +7,7 @@ from utils import json_utils, code_generator
 def test_conversion_config_roundtrip(monkeypatch, tmp_path):
     conf_file = tmp_path / "conv.json"
     out_dir = tmp_path / "out"
-    monkeypatch.setattr(json_utils, "CONVERSION_CONFIG_PATH", str(conf_file))
+    monkeypatch.setattr(json_utils, "get_conversion_config_path", lambda key=None: str(conf_file))
 
     patterns = [{"name": "UserPat", "regex": r"user=(\w+)"}]
     monkeypatch.setattr(json_utils, "load_all_patterns", lambda: patterns)
@@ -19,7 +19,7 @@ def test_conversion_config_roundtrip(monkeypatch, tmp_path):
         ],
     }
 
-    json_utils.save_conversion_config(data)
+    json_utils.save_conversion_config(data, log_key="app")
     assert conf_file.exists()
     with open(conf_file, "r", encoding="utf-8") as f:
         text = f.read()
@@ -27,10 +27,12 @@ def test_conversion_config_roundtrip(monkeypatch, tmp_path):
 
     assert "regex" not in text
     assert saved["mappings"][0]["pattern"] == "UserPat"
+    assert saved["log_key"] == "app"
     assert "regex" not in saved["mappings"][0]
 
-    loaded = json_utils.load_conversion_config()
+    loaded = json_utils.load_conversion_config("app")
     assert loaded["mappings"][0]["regex"] == r"user=(\w+)"
+    assert loaded["log_key"] == "app"
 
     paths = code_generator.generate_files(loaded["header"], loaded["mappings"], patterns, out_dir)
     assert any(path.endswith("cef_converter.py") for path in paths)

--- a/tests/test_open_code_generator.py
+++ b/tests/test_open_code_generator.py
@@ -21,9 +21,10 @@ def test_open_code_generator_selects_key(monkeypatch):
     captured = {}
 
     class DummyDialog:
-        def __init__(self, parent, per_log_patterns=None, logs=None):
+        def __init__(self, parent, per_log_patterns=None, logs=None, log_key=None):
             captured["patterns"] = per_log_patterns
             captured["logs"] = logs
+            captured["log_key"] = log_key
         def grab_set(self):
             pass
 
@@ -33,3 +34,4 @@ def test_open_code_generator_selects_key(monkeypatch):
 
     assert captured["patterns"][0]["name"] == "A"
     assert captured["logs"] == []
+    assert captured["log_key"] is None


### PR DESCRIPTION
## Summary
- support storing multiple conversion configs keyed by log name
- pass log key info through GUI code generator dialog
- update tests for new parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438be78cec832bbd8375107202da30