### PR TITLE
Fix parentheses handling in regex builder

### DIFF
--- a/core/regex/regex_builder.py
+++ b/core/regex/regex_builder.py
@@ -2,7 +2,7 @@ import re
 from typing import List, Literal, Optional
 from .enum_generator import EnumRegexGenerator
 from .generalizer import generalize_token
-from core.tokenizer.tree_tokenizer import build_token_tree, flatten_token_tree
+from core.tokenizer.tokenizer import tokenize
 from utils.text_utils import common_prefix, common_suffix
 
 
@@ -117,8 +117,7 @@ def build_draft_regex_from_examples(
     tokens_by_line: List[List[str]] = []
 
     for line in lines:
-        tree = build_token_tree(line.strip())
-        pairs = flatten_token_tree(tree)
+        pairs = tokenize(line.strip())
 
         tokens = [val for val, kind in pairs if kind == 'token']
         seps = [val for val, kind in pairs if kind == 'sep']

--- a/tests/test_regex_builder.py
+++ b/tests/test_regex_builder.py
@@ -87,3 +87,12 @@ def test_merge_text_tokens_simple():
     assert re.fullmatch(regex, logs[0])
     assert re.fullmatch(regex, logs[1])
     assert not re.fullmatch(regex, "Database Failure")
+def test_regex_preserves_parentheses():
+    logs = [
+        "session opened for user cyrus by (uid=0)",
+        "session opened for user cyrus by (uid=1)"
+    ]
+    regex = build_draft_regex_from_examples(logs)
+    assert re.fullmatch(regex, logs[0])
+    assert re.fullmatch(regex, logs[1])
+    assert '(' in regex and ')' in regex


### PR DESCRIPTION
## Summary
- ensure regex builder uses simple tokenizer that preserves parentheses
- add regression test for parentheses preservation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684396eadda0832badbcbdba6fc5908d