### PR TITLE
Fix leading separators in regex builder

### DIFF
--- a/core/regex/regex_builder.py
+++ b/core/regex/regex_builder.py
@@ -116,9 +116,20 @@ def build_draft_regex_from_examples(
     sep_columns = []
     tokens_by_line: List[List[str]] = []
 
+    leading_prefix = ""
+    parsed_pairs = []
     for line in lines:
         pairs = tokenize(line.strip())
+        parsed_pairs.append(pairs)
+    if parsed_pairs and all(p and p[0][1] == 'sep' for p in parsed_pairs):
+        first_vals = {p[0][0] for p in parsed_pairs}
+        if len(first_vals) == 1:
+            leading_prefix = re.escape(parsed_pairs[0][0][0])
+            for p in parsed_pairs:
+                p.pop(0)
 
+    for pairs in parsed_pairs:
+        
         tokens = [val for val, kind in pairs if kind == 'token']
         seps = [val for val, kind in pairs if kind == 'sep']
 
@@ -233,6 +244,8 @@ def build_draft_regex_from_examples(
         i += 1
 
     core_pattern = ''.join(token_patterns)
+    if leading_prefix:
+        core_pattern = leading_prefix + core_pattern
 
     if window_left:
         core_pattern = f"(?<={re.escape(window_left)}){core_pattern}"

--- a/tests/test_regex_builder.py
+++ b/tests/test_regex_builder.py
@@ -96,3 +96,16 @@ def test_regex_preserves_parentheses():
     assert re.fullmatch(regex, logs[0])
     assert re.fullmatch(regex, logs[1])
     assert '(' in regex and ')' in regex
+
+
+def test_leading_separator_position_and_parenthesis():
+    logs = [
+        ": session opened for user cyrus by (uid=0)",
+        ": session opened for user cyrus by (uid=1)"
+    ]
+    regex = build_draft_regex_from_examples(logs)
+    assert re.fullmatch(regex, logs[0])
+    assert re.fullmatch(regex, logs[1])
+    assert regex.startswith(re.escape(": "))
+    assert 'session:' not in regex
+    assert '(' in regex and ')' in regex


### PR DESCRIPTION
## Summary
- handle leading separators when building regex from log lines
- prepend detected prefix
- test regex builder with leading colon lines

## Testing
- `pytest tests/test_regex_builder.py::test_leading_separator_position_and_parenthesis -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439929eb3c832b95c39f6f685600d0