### PR TITLE
Add regex snippet dropdown to pattern wizard

### DIFF
--- a/tests/test_pattern_wizard.py
+++ b/tests/test_pattern_wizard.py
@@ -134,3 +134,15 @@ def test_auto_select_category_multi():
     PatternWizardDialog._auto_select_category(wiz)
     assert wiz.category_var.get() == "Multiple"
 
+
+def test_on_snippet_selected():
+    wiz = PatternWizardDialog.__new__(PatternWizardDialog)
+    wiz.regex_entry = DummyEntry()
+    wiz.snippet_var = DummyVar("Digits")
+    wiz.snippet_map = {"Digits": "\\d+"}
+    wiz.SNIPPET_DEFAULT = "Insert"
+
+    PatternWizardDialog._on_snippet_selected(wiz)
+    assert wiz.regex_entry.get() == "\\d+"
+    assert wiz.snippet_var.get() == "Insert"
+


### PR DESCRIPTION
## Summary
- provide a list of handy regex snippets
- add dropdown in pattern wizard to insert selected snippet at cursor
- test snippet insertion logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a83713b8832b92c62eccfb62e499