### PR TITLE
Fix code generator mapping refresh

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -29,7 +29,9 @@ class CodeGeneratorDialog(tk.Toplevel):
         self.log_key = log_key
 
         config = json_utils.load_conversion_config(log_key)
-        self.mappings = config.get("mappings") or self._build_initial_mappings()
+        loaded = config.get("mappings") or []
+        initial = self._build_initial_mappings()
+        self.mappings = self._merge_mappings(loaded, initial)
         self._build_ui()
         header_data = config.get("header", {})
         for key, var in self.header_vars.items():
@@ -111,6 +113,17 @@ class CodeGeneratorDialog(tk.Toplevel):
                 mappings.append({"cef": field, "pattern": n, "value": "", "transform": transform})
 
         return mappings
+
+    def _merge_mappings(self, existing: list[dict], initial: list[dict]) -> list[dict]:
+        """Merge mappings loaded from config with defaults based on current patterns."""
+        merged = list(existing)
+        seen = {(m.get("cef"), m.get("pattern"), m.get("value")) for m in merged}
+        for m in initial:
+            key = (m.get("cef"), m.get("pattern"), m.get("value"))
+            if key not in seen:
+                merged.append(m)
+                seen.add(key)
+        return merged
 
     # ------------------------------------------------------------------
     # helpers

--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -96,3 +96,22 @@ def test_initial_mappings_time_transform(monkeypatch):
     tran = [m["transform"] for m in mappings if m["cef"] == "rt"]
     assert tran == ["time"]
 
+
+def test_dialog_merges_new_patterns(monkeypatch):
+    dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
+    dlg.per_log_patterns = [{"name": "NewPat", "regex": "n", "fields": ["deviceVendor"]}]
+    dlg.logs = []
+    dlg.log_key = "app"
+
+    config = {
+        "header": {},
+        "mappings": [{"cef": "deviceVendor", "pattern": "OldPat", "transform": "none", "value": ""}],
+    }
+    monkeypatch.setattr(json_utils, "load_cef_fields", lambda: [{"key": "deviceVendor"}])
+
+    initial = CodeGeneratorDialog._build_initial_mappings(dlg)
+    merged = CodeGeneratorDialog._merge_mappings(dlg, config["mappings"], initial)
+
+    names = {m.get("pattern") for m in merged if m.get("cef") == "deviceVendor"}
+    assert names == {"OldPat", "NewPat"}
+


### PR DESCRIPTION
## Summary
- ensure code generator dialog merges new patterns with saved mappings
- test merging logic in CodeGeneratorDialog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843aaa939a4832b81a57e9edbfd9429