### PR TITLE
Fix merging of placeholders and embed transform logic

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -152,8 +152,12 @@ class CodeGeneratorDialog(tk.Toplevel):
             if key in seen:
                 continue
 
-            # Remove placeholder mapping for the same field
-            if not _is_placeholder(m):
+            if _is_placeholder(m):
+                if any(e.get("cef") == m.get("cef") for e in existing):
+                    # Skip placeholder if a mapping for this field already exists
+                    continue
+            else:
+                # Remove placeholder mapping for the same field
                 for idx in range(len(merged) - 1, -1, -1):
                     current = merged[idx]
                     if current.get("cef") == m.get("cef") and _is_placeholder(current):

--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -147,3 +147,17 @@ def test_merge_replaces_placeholder(monkeypatch):
     assert len(sig) == 1 and sig[0].get("pattern") == "SigPat"
     assert len(name) == 1 and name[0].get("pattern") == "NamePat"
     assert len(sev) == 1 and sev[0].get("pattern") == "SevPat"
+
+
+def test_merge_skips_placeholder_when_constant_exists(monkeypatch):
+    dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
+    dlg.per_log_patterns = []
+    monkeypatch.setattr(json_utils, "load_cef_field_keys", lambda: ["deviceVendor"])
+    monkeypatch.setattr(json_utils, "load_cef_fields", lambda: [{"key": "deviceVendor"}])
+
+    existing = [{"cef": "deviceVendor", "value": "ACME", "transform": "none"}]
+    initial = CodeGeneratorDialog._build_initial_mappings(dlg)
+    merged = CodeGeneratorDialog._merge_mappings(dlg, existing, initial)
+
+    vendor = [m for m in merged if m["cef"] == "deviceVendor"]
+    assert vendor == existing

--- a/utils/code_generator.py
+++ b/utils/code_generator.py
@@ -61,7 +61,95 @@ def generate_files(
     converter_code = f"""
 {comment}
 import re
-from utils.transform_logic import apply_transform
+from datetime import timezone
+from dateutil import parser as date_parser
+from typing import Any, Dict, List
+
+
+def _normalize_time(value: str) -> str:
+    '''Parse an arbitrary date string and return ISO-8601 in UTC.'''
+    if not value:
+        return value
+    try:
+        if '/' in value:
+            dt = date_parser.parse(value, dayfirst=True)
+        else:
+            dt = date_parser.parse(value)
+    except (ValueError, TypeError):
+        return value
+    if not dt.tzinfo:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _apply_basic_transform(value: str, transform: str) -> str:
+    '''Apply a basic string transformation.'''
+    if value is None:
+        value = ""
+    if transform == "lower":
+        return value.lower()
+    if transform == "upper":
+        return value.upper()
+    if transform == "capitalize":
+        return value.title()
+    if transform == "sentence":
+        return value[:1].upper() + value[1:].lower() if value else value
+    if transform == "time":
+        return _normalize_time(value)
+    return value
+
+
+def _reorder_tokens(value: str, regex: str, order: List[int]) -> str:
+    '''Reorder regex-derived tokens according to the provided order.'''
+    try:
+        pat = re.compile(regex)
+    except re.error:
+        return value
+    m = pat.search(value or "")
+    if not m:
+        return value
+    tokens: List[str] = []
+    if m.lastindex:
+        pos = m.start()
+        for i in range(1, (m.lastindex or 0) + 1):
+            literal = value[pos:m.start(i)]
+            if literal:
+                tokens.append(literal)
+            tokens.append(m.group(i))
+            pos = m.end(i)
+        tail = value[pos:m.end()]
+        if tail:
+            tokens.append(tail)
+    else:
+        span = value[m.start():m.end()]
+        tokens = [t for t in re.split(r"([a-zA-Z]+|\d+|\W)", span) if t]
+    return "".join(tokens[i] for i in order if i < len(tokens))
+
+
+def apply_transform(value: str, transform: Any) -> str:
+    '''Apply a basic or advanced transformation.'''
+    if isinstance(transform, dict):
+        fmt = transform.get("format", "none")
+        if transform.get("token_order") and transform.get("regex"):
+            order = [int(i) for i in transform.get("token_order", [])]
+            value = _reorder_tokens(value, transform["regex"], order)
+        if transform.get("replace_pattern"):
+            pat = re.compile(transform["replace_pattern"])
+            if pat.fullmatch(value or ""):
+                value = transform.get("replace_with", "")
+        if transform.get("value_map"):
+            mapping: Dict[str, str] = transform["value_map"]
+            if value in mapping:
+                value = mapping[value]
+            else:
+                for k, v in mapping.items():
+                    if k in (value or ""):
+                        value = (value or "").replace(k, v)
+        return _apply_basic_transform(value, fmt)
+    return _apply_basic_transform(value, str(transform))
+
 
 class LogToCEFConverter:
     def __init__(self):


### PR DESCRIPTION
## Summary
- avoid adding placeholder mappings when a constant mapping exists
- embed `apply_transform` logic inside generated converters so they can run standalone

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843bf57936c832b90a54df09dce2b5d