### PR TITLE
Filter compiled patterns by config

### DIFF
--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -176,3 +176,25 @@ def test_generate_files_handles_quotes(tmp_path):
     result = conv.convert_line('foo')
     assert 'dvc=foo' in result
 
+
+def test_generate_files_filters_unused_patterns(tmp_path):
+    header = {'CEF Version': '0'}
+    patterns = [
+        {'name': 'Used', 'regex': r'us'},
+        {'name': 'Unused', 'regex': r'un'},
+    ]
+    mappings = [
+        {
+            'cef': 'msg',
+            'pattern': 'Used',
+            'transform': 'none',
+        }
+    ]
+    paths = generate_files(header, mappings, patterns, tmp_path)
+    spec = importlib.util.spec_from_file_location('cef_converter', paths[0])
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    conv = module.LogToCEFConverter()
+    assert set(conv.compiled_patterns.keys()) == {'Used'}
+
+

--- a/utils/code_generator.py
+++ b/utils/code_generator.py
@@ -42,6 +42,20 @@ def generate_files(
     """
     os.makedirs(output_dir, exist_ok=True)
 
+    # Filter provided patterns to only those referenced in mappings
+    used_names = set()
+    for m in mappings:
+        p = m.get("pattern")
+        if isinstance(p, dict):
+            name = p.get("name")
+        else:
+            name = p
+        if name:
+            used_names.add(name)
+
+    if used_names:
+        patterns = [p for p in patterns if p.get("name") in used_names]
+
     suffix = f"_{log_name}" if log_name else ""
     converter_path = os.path.join(output_dir, f"cef_converter{suffix}.py")
     main_path = os.path.join(output_dir, f"main_cef_converter{suffix}.py")


### PR DESCRIPTION
## Summary
- filter pattern list in generated converter to only include names referenced in mappings
- test that unused patterns are excluded from the generated converter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843c1f0c194832b8b0b0dc306ef7f26