### PR TITLE
Update main_code template and add execution test

### DIFF
--- a/tests/test_main_cef_converter.py
+++ b/tests/test_main_cef_converter.py
@@ -1,0 +1,35 @@
+import sys
+import subprocess
+from utils.code_generator import generate_files
+
+
+def test_generated_main_runs(tmp_path):
+    header = {
+        'CEF Version': '0',
+        'Device Vendor': 'ACME',
+        'Device Product': 'LP',
+        'Device Version': '1.0',
+        'Event Class ID': '42',
+        'Event Name': 'Test',
+        'Severity (int)': '5',
+    }
+    patterns = [{
+        'name': 'UserName',
+        'regex': r'user=(\w+)',
+    }]
+    mappings = [{
+        'cef': 'suser',
+        'pattern': 'UserName',
+        'group': 1,
+        'transform': 'none',
+    }]
+
+    paths = generate_files(header, mappings, patterns, tmp_path)
+    main_path = paths[1]
+
+    with open(tmp_path / 'input.log', 'w', encoding='utf-8') as f:
+        f.write('user=john\n')
+
+    subprocess.run([sys.executable, main_path], cwd=tmp_path, check=True)
+
+    assert (tmp_path / 'output.cef').exists()

--- a/utils/code_generator.py
+++ b/utils/code_generator.py
@@ -224,26 +224,28 @@ class LogToCEFConverter:
 """
 
     comment_main = f"# Runner for log: {log_name}" if log_name else "# Runner"
-    main_code = dedent(f"""
-    {comment_main}
-    from cef_converter{suffix} import LogToCEFConverter
+    main_code = dedent(
+        f"""
+{comment_main}
+from cef_converter{suffix} import LogToCEFConverter
 
-    def main():
-        conv = LogToCEFConverter()
-        with open('input.log', 'r', encoding='utf-8') as fin, \
-             open('output.cef', 'w', encoding='utf-8') as fout, \
-             open('error.log', 'w', encoding='utf-8') as ferr:
-            for line in fin:
-                line = line.rstrip('\n')
-                cef = conv.convert_line(line)
-                fout.write(cef + '\n')
-                cov = conv.coverage_score(line)
-                if cov < 100.0:
-                    conv.log_incomplete_coverage(line, cov, ferr)
+def main():
+    conv = LogToCEFConverter()
+    with open('input.log', 'r', encoding='utf-8') as fin, \
+         open('output.cef', 'w', encoding='utf-8') as fout, \
+         open('error.log', 'w', encoding='utf-8') as ferr:
+        for line in fin:
+            line = line.rstrip('\\n')
+            cef = conv.convert_line(line)
+            fout.write(cef + '\\n')
+            cov = conv.coverage_score(line)
+            if cov < 100.0:
+                conv.log_incomplete_coverage(line, cov, ferr)
 
-    if __name__ == '__main__':
-        main()
-    """)
+if __name__ == '__main__':
+    main()
+"""
+    ).lstrip()
 
     with open(converter_path, 'w', encoding='utf-8') as f:
         f.write(converter_code)


### PR DESCRIPTION
## Summary
- escape newlines in generated main script
- strip leading newline from main template
- add test to execute generated main_cef_converter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c64d3964832b9f9ef8d3fcc1f139