### PR TITLE
Fix header persistence

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -331,7 +331,9 @@ class CodeGeneratorDialog(tk.Toplevel):
     def _on_preview(self):
         import tempfile, pathlib
 
-        header = {k: v.get() for k, v in self.header_vars.items()}
+        # Use only the CEF version for code generation. Remaining header values
+        # are provided via constant mappings.
+        header = {"CEF Version": self.header_vars["CEF Version"].get()}
         mappings = self._gather_mappings()
         patterns = self._collect_patterns()
 
@@ -352,7 +354,9 @@ class CodeGeneratorDialog(tk.Toplevel):
         text.pack(fill="both", expand=True)
 
     def _on_generate(self):
-        header = {k: v.get() for k, v in self.header_vars.items()}
+        # When generating files, only pass the CEF version. Other header values
+        # should be supplied via constant mappings.
+        header = {"CEF Version": self.header_vars["CEF Version"].get()}
         mappings = self._gather_mappings()
         patterns = self._collect_patterns()
         out_dir = os.path.join(os.getcwd(), "generated_cef")
@@ -447,7 +451,9 @@ class CodeGeneratorDialog(tk.Toplevel):
 
     # ------------------------------------------------------------------
     def _save_config(self):
-        header = {k: v.get() for k, v in self.header_vars.items()}
+        # Only persist the CEF version in the header. Other values are derived
+        # from mappings and should not be saved.
+        header = {"CEF Version": self.header_vars["CEF Version"].get()}
         data = {"header": header, "mappings": self.mappings}
         json_utils.save_conversion_config(data, self.log_key)
 

--- a/tests/test_code_generator_dialog.py
+++ b/tests/test_code_generator_dialog.py
@@ -161,3 +161,32 @@ def test_merge_skips_placeholder_when_constant_exists(monkeypatch):
 
     vendor = [m for m in merged if m["cef"] == "deviceVendor"]
     assert vendor == existing
+
+
+def test_save_config_persists_only_version(monkeypatch):
+    class DummyVar:
+        def __init__(self, val):
+            self.val = val
+        def get(self):
+            return self.val
+
+    captured = {}
+
+    def fake_save(data, key):
+        captured['data'] = data
+        captured['key'] = key
+
+    dlg = CodeGeneratorDialog.__new__(CodeGeneratorDialog)
+    dlg.header_vars = {
+        "CEF Version": DummyVar("0"),
+        "Device Vendor": DummyVar("ACME"),
+    }
+    dlg.mappings = []
+    dlg.log_key = "app"
+
+    monkeypatch.setattr(json_utils, "save_conversion_config", fake_save)
+
+    CodeGeneratorDialog._save_config(dlg)
+
+    assert captured['data']['header'] == {"CEF Version": "0"}
+    assert captured['key'] == "app"


### PR DESCRIPTION
## Summary
- keep only the CEF version in saved header configs
- ensure preview and generation only use the CEF version
- test saving config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843cc606320832bb39a8a1779c4bae6