### PR TITLE
Translate interface to English

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -75,24 +75,24 @@ class AppWindow(tk.Frame):
         ctrl = tk.Frame(self)
         ctrl.grid(row=1, column=0, sticky="w", padx=5, pady=5)
 
-        tk.Button(ctrl, text="Загрузить лог", command=self.load_log_file).pack(side="left", padx=5)
-        tk.Button(ctrl, text="← Назад", command=self.prev_page).pack(side="left", padx=5)
-        tk.Button(ctrl, text="Вперёд →", command=self.next_page).pack(side="left", padx=5)
+        tk.Button(ctrl, text="Load Log", command=self.load_log_file).pack(side="left", padx=5)
+        tk.Button(ctrl, text="← Prev", command=self.prev_page).pack(side="left", padx=5)
+        tk.Button(ctrl, text="Next →", command=self.next_page).pack(side="left", padx=5)
 
-        tk.Label(ctrl, text="Строк на странице:").pack(side="left", padx=(20, 5))
+        tk.Label(ctrl, text="Lines per page:").pack(side="left", padx=(20, 5))
 
         self.spinbox = tk.Spinbox(ctrl, from_=1, to=1000, width=5, command=self.update_page_size)
         self.spinbox.pack(side="left")
         self.spinbox.delete(0, tk.END)
         self.spinbox.insert(0, str(self.page_size))
 
-        self.status_label = tk.Label(ctrl, text="Стр. 0 из 0")
+        self.status_label = tk.Label(ctrl, text="Page 0 of 0")
         self.status_label.pack(side="left", padx=15)
-        self.coverage_label = tk.Label(ctrl, text="Покрытие: 0%")
+        self.coverage_label = tk.Label(ctrl, text="Coverage: 0%")
         self.coverage_label.pack(side="left", padx=15)
-        tk.Button(ctrl, text="Создать паттерн", command=self.open_pattern_wizard).pack(side="left", padx=5)
-        tk.Button(ctrl, text="Сохранить паттерны", command=self.save_current_patterns).pack(side="left", padx=5)
-        tk.Button(ctrl, text="Генератор кода", command=self.open_code_generator).pack(side="left", padx=5)
+        tk.Button(ctrl, text="Create Pattern", command=self.open_pattern_wizard).pack(side="left", padx=5)
+        tk.Button(ctrl, text="Save Patterns", command=self.save_current_patterns).pack(side="left", padx=5)
+        tk.Button(ctrl, text="Code Generator", command=self.open_code_generator).pack(side="left", padx=5)
         self.text_area.bind("<Motion>", self.on_hover)
         self.text_area.bind("<Leave>", lambda e: self.tooltip.hidetip())
 
@@ -197,7 +197,7 @@ class AppWindow(tk.Frame):
         pattern_index_map = {key: i for i, key in enumerate(pattern_keys)}
 
         coverage = self._compute_coverage(active_names)
-        self.coverage_label.config(text=f"Покрытие: {coverage:.1f}%")
+        self.coverage_label.config(text=f"Coverage: {coverage:.1f}%")
 
         # Проверка на пересекающиеся паттерны
         def has_overlap(matches: list[dict]) -> bool:
@@ -238,7 +238,7 @@ class AppWindow(tk.Frame):
 
     def _update_status(self):
         total_pages = (len(self.logs) - 1) // self.page_size + 1 if self.logs else 0
-        self.status_label.config(text=f"Стр. {self.current_page + 1} из {total_pages}")
+        self.status_label.config(text=f"Page {self.current_page + 1} of {total_pages}")
 
     def next_page(self):
         if (self.current_page + 1) * self.page_size < len(self.logs):
@@ -257,7 +257,7 @@ class AppWindow(tk.Frame):
             names = [self.tag_map[t]["name"] for t in tags if t in self.tag_map]
             if len(names) > 1:
                 self.tooltip.schedule(
-                    "Паттерны: " + ", ".join(names), event.x_root, event.y_root
+                    "Patterns: " + ", ".join(names), event.x_root, event.y_root
                 )
             else:
                 self.tooltip.unschedule()
@@ -267,17 +267,17 @@ class AppWindow(tk.Frame):
     def open_pattern_wizard(self):
         selections = self.get_selected_lines()
         if not selections:
-            messagebox.showwarning("Нет выделения", "Пожалуйста, выделите строки для генерации паттерна.")
+            messagebox.showwarning("No Selection", "Please select lines to generate a pattern.")
             return
 
         # Получаем CEF-поля и путь к лог-файлу
         cef_fields = getattr(self.pattern_panel, "cef_fields", [])
         source_file = getattr(self, "source_path", "example.log")
 
-        # Имя набора паттернов по умолчанию
+        # Default pattern set name
         default_name = get_log_name_for_file(source_file) or os.path.basename(source_file)
         log_name = simpledialog.askstring(
-            "Имя набора", "Введите имя для пер-лог паттернов:",
+            "Set Name", "Enter name for per-log patterns:",
             initialvalue=default_name,
             parent=self
         )
@@ -306,7 +306,7 @@ class AppWindow(tk.Frame):
             self.render_page()
         except Exception as e:
             logger.error("[PatternWizard] %s", e)
-            messagebox.showerror("Ошибка", f"Не удалось открыть мастер: {e}")
+            messagebox.showerror("Error", f"Failed to open wizard: {e}")
 
     def open_code_generator(self):
         """Open the code generator dialog (stub)."""
@@ -315,7 +315,7 @@ class AppWindow(tk.Frame):
             if not per_patterns:
                 keys = list(load_log_key_map().keys())
                 if keys:
-                    prompt = "Выберите ключ лог-файла:\n" + ", ".join(keys)
+                    prompt = "Choose log file key:\n" + ", ".join(keys)
                     key = simpledialog.askstring("Log Key", prompt, parent=self)
                     if key:
                         per_patterns = load_per_log_patterns_by_key(key)
@@ -327,7 +327,7 @@ class AppWindow(tk.Frame):
             dlg.grab_set()
         except Exception as e:
             logger.error("[CodeGenerator] %s", e)
-            messagebox.showerror("Ошибка", f"Не удалось открыть генератор: {e}")
+            messagebox.showerror("Error", f"Failed to open generator: {e}")
 
     def get_selected_lines(self):
         """Return selected fragments along with their full line context."""
@@ -356,12 +356,12 @@ class AppWindow(tk.Frame):
 
     def save_current_patterns(self):
         if not getattr(self, "source_path", None):
-            messagebox.showinfo("Нет файла", "Сначала загрузите лог-файл")
+            messagebox.showinfo("No File", "Load a log file first")
             return
 
         default_name = get_log_name_for_file(self.source_path) or os.path.basename(self.source_path)
         log_name = simpledialog.askstring(
-            "Имя набора", "Введите имя для пер-лог паттернов:",
+            "Set Name", "Enter name for per-log patterns:",
             initialvalue=default_name,
             parent=self
         )
@@ -399,4 +399,4 @@ class AppWindow(tk.Frame):
         self._cache_matches()
         self.render_page()
 
-        messagebox.showinfo("Готово", "Паттерны сохранены.")
+        messagebox.showinfo("Done", "Patterns saved.")

--- a/gui/cef_field_dialog.py
+++ b/gui/cef_field_dialog.py
@@ -7,7 +7,7 @@ class CEFFieldDialog(tk.Toplevel):
 
     def __init__(self, parent, cef_fields, pattern_name: str, initial=None):
         super().__init__(parent)
-        self.title(f"CEF-поля для {pattern_name}")
+        self.title(f"CEF Fields for {pattern_name}")
         self.result = None
         self.var_map = {}
         self.cef_fields = cef_fields or []

--- a/gui/pattern_wizard.py
+++ b/gui/pattern_wizard.py
@@ -13,19 +13,19 @@ from utils.json_utils import save_user_pattern, save_per_log_pattern
 
 
 SNIPPETS = [
-    ("Одно слово (любые символы, кроме пробелов)", r"\S+"),
-    ("Одно слово только из букв", r"[a-zA-Z]+"),
-    ("Одно слово только из цифр", r"\d+"),
-    ("Слово из букв и цифр", r"[a-zA-Z0-9]+"),
-    ("Слово из любых символов", r"[^ \t\n\r\f\v]+"),
-    ("Строка до конца строки", r".*"),
-    ("Строка до конца строки (нежадно)", r".*?"),
-    ("Одно число фиксированной длины (3)", r"\d{3}"),
-    ("Одно число, минимум N цифр", r"\d{2,}"),
-    ("Символы до двоеточия", r"[^:]+"),
-    ("Фрагмент в квадратных скобках", r"\[[^\]]+\]"),
-    ("Фрагмент в круглых скобках", r"\([^)]+\)"),
-    ("Линия с тегом", r"[a-zA-Z0-9._-]+:")
+    ("One word (non-space characters)", r"\S+"),
+    ("Letters only word", r"[a-zA-Z]+"),
+    ("Digits only", r"\d+"),
+    ("Alphanumeric word", r"[a-zA-Z0-9]+"),
+    ("Word of any characters", r"[^ \t\n\r\f\v]+"),
+    ("Line to end", r".*"),
+    ("Line to end (non-greedy)", r".*?"),
+    ("Fixed length number (3)", r"\d{3}"),
+    ("Number with at least N digits", r"\d{2,}"),
+    ("Chars until colon", r"[^:]+"),
+    ("Segment in []", r"\[[^\]]+\]"),
+    ("Segment in ()", r"\([^)]+\)"),
+    ("Line with tag", r"[a-zA-Z0-9._-]+:")
 ]
 
 
@@ -34,14 +34,14 @@ class PatternWizardDialog(tk.Toplevel):
     def __init__(self, parent, selected_lines, context_lines, cef_fields, source_file, log_name, categories=None, fragment_context=None):
 
         super().__init__(parent)
-        self.title("Создание нового паттерна")
+        self.title("Create New Pattern")
         # Минимальный размер окна, но пользователь может растягивать его
         self.minsize(800, 600)
 
         menu_bar = tk.Menu(self)
         file_menu = tk.Menu(menu_bar, tearoff=0)
-        file_menu.add_command(label="Сохранить", command=self._save, accelerator="Ctrl+S")
-        menu_bar.add_cascade(label="Файл", menu=file_menu)
+        file_menu.add_command(label="Save", command=self._save, accelerator="Ctrl+S")
+        menu_bar.add_cascade(label="File", menu=file_menu)
         self.config(menu=menu_bar)
         self.bind_all("<Control-s>", lambda e: self._save())
 
@@ -81,13 +81,13 @@ class PatternWizardDialog(tk.Toplevel):
         self.regex_var = tk.StringVar()
         self.case_insensitive = tk.BooleanVar()
         self.digit_mode_values = {
-            "Стандартный": "standard",
-            "Фиксированная длина": "always_fixed_length",
-            "Всегда \\d+": "always_plus",
-            "С выставлением минимальной длины": "min_length",
-            "Фикс. или мин.": "fixed_and_min",
+            "Standard": "standard",
+            "Fixed length": "always_fixed_length",
+            "Always \\d+": "always_plus",
+            "Set minimum length": "min_length",
+            "Fixed or min.": "fixed_and_min",
         }
-        self.digit_mode_display_var = tk.StringVar(value="Фиксированная длина")
+        self.digit_mode_display_var = tk.StringVar(value="Fixed length")
         self.digit_mode_var = tk.StringVar(value="always_fixed_length")
         self.digit_min_length_var = tk.IntVar(value=1)
         self.merge_text_tokens_var = tk.BooleanVar(value=True)
@@ -102,7 +102,7 @@ class PatternWizardDialog(tk.Toplevel):
         self._build_ui()
         total_pages = (len(self.context_lines) - 1) // self.page_size + 1
         self.total_pages = total_pages
-        self.page_label_var.set(f"Страница {self.current_page + 1} из {total_pages}")
+        self.page_label_var.set(f"Page {self.current_page + 1} of {total_pages}")
         self._generate_regex()
 
     def _build_ui(self):
@@ -110,10 +110,10 @@ class PatternWizardDialog(tk.Toplevel):
         top_frame = ttk.Frame(self)
         top_frame.pack(fill="x", pady=5)
 
-        ttk.Label(top_frame, text="Имя:").pack(side="left")
+        ttk.Label(top_frame, text="Name:").pack(side="left")
         ttk.Entry(top_frame, textvariable=self.name_var, width=20).pack(side="left", padx=5)
 
-        ttk.Label(top_frame, text="Категория:").pack(side="left")
+        ttk.Label(top_frame, text="Category:").pack(side="left")
 
         self.category_label = ttk.Label(top_frame, textvariable=self.category_var, width=20)
         self.category_label.pack(side="left", padx=5)
@@ -127,7 +127,7 @@ class PatternWizardDialog(tk.Toplevel):
 
         toggle_adv = ttk.Checkbutton(
             left_frame,
-            text="Показать дополнительные параметры",
+            text="Show advanced options",
             variable=self.show_advanced,
             command=self._toggle_advanced,
         )
@@ -135,41 +135,41 @@ class PatternWizardDialog(tk.Toplevel):
 
         self.advanced_frame = ttk.Frame(left_frame)
 
-        ci = ttk.Checkbutton(self.advanced_frame, text="Игнорировать регистр", variable=self.case_insensitive)
+        ci = ttk.Checkbutton(self.advanced_frame, text="Ignore case", variable=self.case_insensitive)
         ci.pack(anchor="w", pady=2)
 
         row = ttk.Frame(self.advanced_frame)
         row.pack(anchor="w")
-        ttk.Label(row, text="Режим чисел:").pack(side="left")
+        ttk.Label(row, text="Number mode:").pack(side="left")
         dm = ttk.Combobox(row, textvariable=self.digit_mode_display_var, values=list(self.digit_mode_values.keys()), width=22, state="readonly")
         dm.pack(side="left", padx=2)
         self.digit_mode_display_var.trace_add("write", lambda *_: self._on_digit_mode_change())
 
         row = ttk.Frame(self.advanced_frame)
         row.pack(anchor="w")
-        ttk.Label(row, text="Мин. длина числа:").pack(side="left")
+        ttk.Label(row, text="Min number length:").pack(side="left")
         ml = ttk.Spinbox(row, from_=1, to=10, textvariable=self.digit_min_length_var, width=5)
         ml.pack(side="left", padx=2)
 
-        mt = ttk.Checkbutton(self.advanced_frame, text="Объединять текст", variable=self.merge_text_tokens_var)
+        mt = ttk.Checkbutton(self.advanced_frame, text="Merge text", variable=self.merge_text_tokens_var)
         mt.pack(anchor="w", pady=2)
-        pa = ttk.Checkbutton(self.advanced_frame, text="Использовать |", variable=self.prefer_alternatives_var)
+        pa = ttk.Checkbutton(self.advanced_frame, text="Use |", variable=self.prefer_alternatives_var)
         pa.pack(anchor="w", pady=2)
-        bp = ttk.Checkbutton(self.advanced_frame, text="Префикс. слияние", variable=self.merge_by_prefix_var)
+        bp = ttk.Checkbutton(self.advanced_frame, text="Prefix merge", variable=self.merge_by_prefix_var)
         bp.pack(anchor="w", pady=2)
 
         row = ttk.Frame(self.advanced_frame)
         row.pack(anchor="w")
-        ttk.Label(row, text="Макс. вариантов:").pack(side="left")
+        ttk.Label(row, text="Max options:").pack(side="left")
         mx = ttk.Spinbox(row, from_=1, to=20, textvariable=self.max_enum_options_var, width=5)
         mx.pack(side="left", padx=2)
 
         row = ttk.Frame(self.advanced_frame)
         row.pack(anchor="w")
-        ttk.Label(row, text="Окно слева:").pack(side="left")
+        ttk.Label(row, text="Window left:").pack(side="left")
         wl = ttk.Entry(row, textvariable=self.window_left_var, width=8)
         wl.pack(side="left", padx=2)
-        ttk.Label(row, text="Окно справа:").pack(side="left")
+        ttk.Label(row, text="Window right:").pack(side="left")
         wr = ttk.Entry(row, textvariable=self.window_right_var, width=8)
         wr.pack(side="left", padx=2)
 
@@ -177,26 +177,26 @@ class PatternWizardDialog(tk.Toplevel):
         right_frame.pack(side="left", fill="both", expand=True)
 
         # Tooltips
-        self._add_tip(ci, "Регулярное выражение будет нечувствительно к регистру")
-        self._add_tip(dm, "Как обрабатывать числа в строках")
-        self._add_tip(ml, "Минимальная длина числа при генерации")
-        self._add_tip(mt, "Объединять разные слова в один блок")
-        self._add_tip(pa, "Предпочитать варианты через |")
-        self._add_tip(bp, "Объединять по общему префиксу")
-        self._add_tip(mx, "Максимальное число вариантов в перечислении")
-        self._add_tip(wl, "Слева от совпадения")
-        self._add_tip(wr, "Справа от совпадения")
+        self._add_tip(ci, "Regex will be case-insensitive")
+        self._add_tip(dm, "How to handle numbers")
+        self._add_tip(ml, "Minimum number length")
+        self._add_tip(mt, "Merge different words")
+        self._add_tip(pa, "Prefer alternatives via |")
+        self._add_tip(bp, "Merge by common prefix")
+        self._add_tip(mx, "Maximum number of options")
+        self._add_tip(wl, "Left of match")
+        self._add_tip(wr, "Right of match")
 
         # Скрыть блок с параметрами по умолчанию
         self._toggle_advanced()
 
         # Регулярное выражение
-        regex_frame = ttk.LabelFrame(right_frame, text="Сгенерированное регулярное выражение")
+        regex_frame = ttk.LabelFrame(right_frame, text="Generated regular expression")
         regex_frame.pack(fill="x", padx=5, pady=5)
         self.regex_entry = tk.Text(regex_frame, height=2)
         self.regex_entry.pack(fill="x")
 
-        self.SNIPPET_DEFAULT = "Вставить шаблон..."
+        self.SNIPPET_DEFAULT = "Insert snippet..."
         self.snippet_var = tk.StringVar(value=self.SNIPPET_DEFAULT)
         self.snippet_map = {label: regex for label, regex in SNIPPETS}
         snippet_combo = ttk.Combobox(
@@ -209,16 +209,16 @@ class PatternWizardDialog(tk.Toplevel):
         snippet_combo.pack(anchor="w", pady=2)
         snippet_combo.bind("<<ComboboxSelected>>", self._on_snippet_selected)
 
-        undo_btn = ttk.Button(regex_frame, text="← Предыдущая", command=self._undo_regex)
+        undo_btn = ttk.Button(regex_frame, text="← Previous", command=self._undo_regex)
         undo_btn.pack(side="right", padx=5)
 
         btn_frame = ttk.Frame(right_frame)
         btn_frame.pack(fill="x")
-        ttk.Button(btn_frame, text="Обновить", command=self._generate_regex).pack(side="left", padx=2)
-        ttk.Button(btn_frame, text="Применить", command=self._apply_regex).pack(side="left", padx=2)
+        ttk.Button(btn_frame, text="Update", command=self._generate_regex).pack(side="left", padx=2)
+        ttk.Button(btn_frame, text="Apply", command=self._apply_regex).pack(side="left", padx=2)
 
         # Примеры
-        example_frame = ttk.LabelFrame(right_frame, text="Примеры")
+        example_frame = ttk.LabelFrame(right_frame, text="Examples")
         example_frame.pack(fill="both", expand=True, padx=5, pady=5)
         self.example_list = tk.Listbox(example_frame, height=4)
         self.example_list.pack(side="left", fill="both", expand=True)
@@ -228,20 +228,20 @@ class PatternWizardDialog(tk.Toplevel):
 
         btns = ttk.Frame(example_frame)
         btns.pack(side="left", fill="y", padx=5)
-        ttk.Button(btns, text="Удалить", command=self._remove_example).pack(pady=2)
-        ttk.Button(btns, text="Добавить выделение", command=self._add_selection).pack(pady=2)
+        ttk.Button(btns, text="Delete", command=self._remove_example).pack(pady=2)
+        ttk.Button(btns, text="Add selection", command=self._add_selection).pack(pady=2)
 
         # Список совпадений
-        self.match_frame = ttk.LabelFrame(self, text="Совпадения")
+        self.match_frame = ttk.LabelFrame(self, text="Matches")
         self.match_frame.pack(fill="both", expand=True, padx=5, pady=5)
         self.match_text = tk.Text(self.match_frame, height=10)
         self.match_text.pack(fill="both", expand=True)
 
         mode_frame = ttk.Frame(self)
         mode_frame.pack(fill="x", pady=5)
-        ttk.Radiobutton(mode_frame, text="Совпадения", variable=self.show_mode, value="matches", command=self._on_mode_change).pack(side="left", padx=5)
-        ttk.Radiobutton(mode_frame, text="Отсутствие", variable=self.show_mode, value="absent", command=self._on_mode_change).pack(side="left", padx=5)
-        ttk.Radiobutton(mode_frame, text="Конфликты", variable=self.show_mode, value="conflicts", command=self._on_mode_change).pack(side="left", padx=5)
+        ttk.Radiobutton(mode_frame, text="Matches", variable=self.show_mode, value="matches", command=self._on_mode_change).pack(side="left", padx=5)
+        ttk.Radiobutton(mode_frame, text="Absent", variable=self.show_mode, value="absent", command=self._on_mode_change).pack(side="left", padx=5)
+        ttk.Radiobutton(mode_frame, text="Conflicts", variable=self.show_mode, value="conflicts", command=self._on_mode_change).pack(side="left", padx=5)
 
         nav = ttk.Frame(self)
         nav.pack(fill="x")
@@ -249,13 +249,13 @@ class PatternWizardDialog(tk.Toplevel):
         ttk.Label(nav, textvariable=self.page_label_var).pack(side="left", padx=5)
         ttk.Button(nav, text="→", command=self.next_page).pack(side="left")
 
-        # CEF-поля
-        field_frame = ttk.LabelFrame(left_frame, text="CEF-поля")
+        # CEF fields
+        field_frame = ttk.LabelFrame(left_frame, text="CEF Fields")
         field_frame.pack(fill="both", expand=True, pady=5)
 
         search_frame = ttk.Frame(field_frame)
         search_frame.pack(fill="x")
-        ttk.Label(search_frame, text="Поиск:").pack(side="left")
+        ttk.Label(search_frame, text="Search:").pack(side="left")
         self.cef_search_var = tk.StringVar()
         search_entry = ttk.Entry(search_frame, textvariable=self.cef_search_var)
         search_entry.pack(side="left", fill="x", expand=True, padx=5)
@@ -279,7 +279,7 @@ class PatternWizardDialog(tk.Toplevel):
         self._auto_select_category()
 
         # Кнопка сохранения
-        ttk.Button(self, text="Сохранить", command=self._save).pack(pady=10)
+        ttk.Button(self, text="Save", command=self._save).pack(pady=10)
 
     def _generate_regex(self):
         try:
@@ -312,7 +312,7 @@ class PatternWizardDialog(tk.Toplevel):
 
         except Exception as e:
             logger.error("[Wizard Error] %s", e)
-            messagebox.showerror("Ошибка генерации", str(e))
+            messagebox.showerror("Generation Error", str(e))
 
     def _apply_regex(self):
         pattern = self.regex_entry.get("1.0", tk.END).strip()
@@ -323,7 +323,7 @@ class PatternWizardDialog(tk.Toplevel):
             flags = re.IGNORECASE if self.case_insensitive.get() else 0
             regex = re.compile(pattern, flags)
         except re.error as e:
-            messagebox.showerror("Ошибка компиляции", str(e))
+            messagebox.showerror("Compilation Error", str(e))
             return
 
         self._push_history(pattern)
@@ -371,7 +371,7 @@ class PatternWizardDialog(tk.Toplevel):
 
         apply_highlighting(self.match_text, matches_by_line, {"preview"}, {"preview": "yellow"})
 
-        self.page_label_var.set(f"Страница {self.current_page + 1} из {total_pages}")
+        self.page_label_var.set(f"Page {self.current_page + 1} of {total_pages}")
 
         self.match_text.config(state="disabled")
 
@@ -383,15 +383,15 @@ class PatternWizardDialog(tk.Toplevel):
 
         if not name or not category or not regex:
             messagebox.showwarning(
-                "Незаполненные поля",
-                "Имя, категория и регулярное выражение обязательны."
+                "Missing Fields",
+                "Name, category and regular expression are required."
             )
             return
 
         if not fields:
             messagebox.showwarning(
-                "Незаполненные поля",
-                "Необходимо выбрать хотя бы одно CEF-поле."
+                "Missing Fields",
+                "Please select at least one CEF field."
             )
             return
 
@@ -407,7 +407,7 @@ class PatternWizardDialog(tk.Toplevel):
         save_user_pattern(pattern_data)
         save_per_log_pattern(self.source_file, name, pattern_data, log_name=self.log_name)
 
-        messagebox.showinfo("Готово", f"Паттерн '{name}' сохранён.")
+        messagebox.showinfo("Done", f"Pattern '{name}' saved.")
         self.destroy()
 
     def _add_tip(self, widget, text):
@@ -464,7 +464,7 @@ class PatternWizardDialog(tk.Toplevel):
         start_line = int(start.split(".")[0])
         end_line = int(end.split(".")[0])
         if start_line != end_line:
-            messagebox.showwarning("Выделение", "Выберите часть одной строки")
+            messagebox.showwarning("Selection", "Select part of a single line")
             return
 
         fragment = self.match_text.get(start, end)

--- a/tests/test_pattern_wizard.py
+++ b/tests/test_pattern_wizard.py
@@ -55,8 +55,8 @@ class DummyCheckbutton:
 
 def test_on_digit_mode_change():
     wiz = PatternWizardDialog.__new__(PatternWizardDialog)
-    wiz.digit_mode_values = {"Фиксированная длина": "always_fixed_length"}
-    wiz.digit_mode_display_var = DummyVar("Фиксированная длина")
+    wiz.digit_mode_values = {"Fixed length": "always_fixed_length"}
+    wiz.digit_mode_display_var = DummyVar("Fixed length")
     wiz.digit_mode_var = DummyVar()
     PatternWizardDialog._on_digit_mode_change(wiz)
     assert wiz.digit_mode_var.get() == "always_fixed_length"


### PR DESCRIPTION
## Summary
- translate app window interface labels to English
- localize pattern wizard labels and messages to English
- fix CEF field dialog title
- update tests for the new English strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d080e5ec832b82143ebfaa9f169f