### PR TITLE
Add installer build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ Open a log file with the **Load Log** button, select lines and run the
 to store per‑log patterns, or the **Code Generator** to produce a CEF
 converter.
 
+## Building an installer
+
+To produce a standalone executable you need [PyInstaller](https://pyinstaller.org).
+Install it and run the helper script:
+
+```bash
+pip install pyinstaller
+python build_installer.py
+```
+
+The resulting installer binary will be placed in the `dist` directory and will
+use the icon from `icon/ALLtoCEF.ico`.
+
 ## Running the tests
 
 The repository includes an extensive test suite. Execute it with:

--- a/build_installer.py
+++ b/build_installer.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+import os
+
+
+def build():
+    root_dir = os.path.dirname(os.path.abspath(__file__))
+    icon_path = os.path.join(root_dir, "icon", "ALLtoCEF.ico")
+    pyinstaller_cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--noconsole",
+        "--onefile",
+        f"--icon={icon_path}",
+        os.path.join(root_dir, "main.py"),
+    ]
+    subprocess.run(pyinstaller_cmd, check=True)
+
+
+if __name__ == "__main__":
+    build()


### PR DESCRIPTION
## Summary
- add `build_installer.py` for building a standalone executable with PyInstaller
- document installer build process in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python build_installer.py`

------
https://chatgpt.com/codex/tasks/task_e_6843d64dc9a0832b8dab17e365d3b55d