### PR TITLE
Add resource helper and bundle data for installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ python build_installer.py
 ```
 
 The resulting installer binary will be placed in the `dist` directory and will
-use the icon from `icon/ALLtoCEF.ico`.
+use the icon from `icon/ALLtoCEF.ico`. The helper script also bundles the
+required built-in pattern and CEF data files.
 
 ## Running the tests
 

--- a/build_installer.py
+++ b/build_installer.py
@@ -6,6 +6,10 @@ import os
 def build():
     root_dir = os.path.dirname(os.path.abspath(__file__))
     icon_path = os.path.join(root_dir, "icon", "ALLtoCEF.ico")
+    data_files = [
+        ("data/cef_fields.json", "data"),
+        ("data/patterns_builtin.json", "data"),
+    ]
     pyinstaller_cmd = [
         sys.executable,
         "-m",
@@ -15,6 +19,10 @@ def build():
         f"--icon={icon_path}",
         os.path.join(root_dir, "main.py"),
     ]
+    for src, dest in data_files:
+        pyinstaller_cmd.append(
+            f"--add-data={os.path.join(root_dir, src)}{os.pathsep}{dest}"
+        )
     subprocess.run(pyinstaller_cmd, check=True)
 
 

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -1,6 +1,17 @@
 import json
 import logging
 import os
+import sys
+
+BASE_DIR = getattr(
+    sys,
+    "_MEIPASS",
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)
+
+
+def resource_path(*parts):
+    return os.path.join(BASE_DIR, *parts)
 
 logger = logging.getLogger(__name__)
 
@@ -19,10 +30,10 @@ def get_conversion_config_path(log_key: str | None = None) -> str:
     return CONVERSION_CONFIG_PATH
 
 USER_PATTERNS_PATH = os.path.join(USER_DATA_DIR, "patterns_user.json")
-BUILTIN_PATTERNS_PATH = os.path.join("data", "patterns_builtin.json")
-LOG_KEY_MAP_PATH = os.path.join("data", "log_key_map.json")
-BUILTIN_PATTERN_KEYS_PATH = os.path.join("data", "builtin_pattern_keys.json")
-CEF_FIELDS_PATH = os.path.join("data", "cef_fields.json")
+BUILTIN_PATTERNS_PATH = resource_path("data", "patterns_builtin.json")
+LOG_KEY_MAP_PATH = resource_path("data", "log_key_map.json")
+BUILTIN_PATTERN_KEYS_PATH = resource_path("data", "builtin_pattern_keys.json")
+CEF_FIELDS_PATH = resource_path("data", "cef_fields.json")
 PER_LOG_PATTERNS_PATH = os.path.join(USER_DATA_DIR, "per_log_patterns.json")
 
 def load_builtin_pattern_keys():


### PR DESCRIPTION
## Summary
- provide `resource_path` helper in `json_utils`
- use it for built-in data constants
- bundle required data files in `build_installer.py`
- note data bundling in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843dc8906ac832bbb5b79daa2ba47e2