### PR TITLE
Improve documentation consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ data/   – built‑in patterns, CEF field definitions and sample logs
 Mappings created automatically for CEF fields of the `Time` category
 use this transformation by default.
 
+## Documentation
+
+Detailed explanations of each window and tool are available in the
+[docs](docs/) directory.
+
 ## UML Diagrams
 
 Automatically generated class and package diagrams are in [docs/uml](docs/uml).

--- a/docs/pattern_wizard.md
+++ b/docs/pattern_wizard.md
@@ -78,7 +78,7 @@ As CEF fields are checked or unchecked the wizard chooses the category automatic
 - `_auto_select_category` – updates the category label based on selected fields.
 - `_on_snippet_selected` – inserts snippet text into the regex entry.
 
-## UML diagrams
+## UML Diagrams
 
 Class and package diagrams generated with PlantUML are located in `docs/uml`. The `classes_LogParserHelper.plantuml` diagram lists all attributes of `PatternWizardDialog` and other GUI classes.
 


### PR DESCRIPTION
## Summary
- link to docs folder in README
- unify Pattern Wizard heading capitalization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843df33d314832ba25b469b98040c64