### PR TITLE
Installer named ALLtoCEF

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ pip install pyinstaller
 python build_installer.py
 ```
 
-The resulting installer binary will be placed in the `dist` directory and will
-use the icon from `icon/ALLtoCEF.ico`. The helper script also bundles the
-required built-in pattern and CEF data files.
+The resulting installer binary `ALLtoCEF` will be placed in the `dist`
+directory and will use the icon from `icon/ALLtoCEF.ico`. The helper script
+also bundles the required built-in pattern and CEF data files.
 
 ## Running the tests
 

--- a/build_installer.py
+++ b/build_installer.py
@@ -17,6 +17,7 @@ def build():
         "--noconsole",
         "--onefile",
         f"--icon={icon_path}",
+        "--name=ALLtoCEF",
         os.path.join(root_dir, "main.py"),
     ]
     for src, dest in data_files:


### PR DESCRIPTION
## Summary
- set executable name with `--name` in build_installer.py
- document that the installer binary is called `ALLtoCEF`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445af72130832b83a8807cac911c8f