### PR TITLE
Fix README icon path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Log Parser Helper icon](icon/ALLtoCEF.ico)
+![Log Parser Helper icon](icon/ALLtoCEF.png)
 
 # Log Parser Helper
 
@@ -58,7 +58,7 @@ python build_installer.py
 ```
 
 The resulting installer binary `ALLtoCEF` will be placed in the `dist`
-directory and will use the icon from `icon/ALLtoCEF.ico`. The helper script
+directory and will use the icon from `icon/ALLtoCEF.png`. The helper script
 also bundles this icon together with the required built-in pattern and CEF
 data files.
 


### PR DESCRIPTION
## Summary
- update README icon reference to use PNG version

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447e96bb5c832ba7a1ed0895fc2597