### PR TITLE
Add action menus

### DIFF
--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -44,6 +44,14 @@ class CodeGeneratorDialog(tk.Toplevel):
         self.protocol("WM_DELETE_WINDOW", self._on_close)
 
     def _build_ui(self):
+        menu_bar = tk.Menu(self)
+        file_menu = tk.Menu(menu_bar, tearoff=0)
+        file_menu.add_command(label="Save Config", command=self._save_config)
+        file_menu.add_command(label="Preview Code ▸", command=self._on_preview)
+        file_menu.add_command(label="Generate Python", command=self._on_generate)
+        menu_bar.add_cascade(label="Actions", menu=file_menu)
+        self.config(menu=menu_bar)
+
         header = ttk.LabelFrame(self, text="CEF Header")
         header.pack(fill="x", padx=10, pady=5)
 

--- a/gui/transform_editor.py
+++ b/gui/transform_editor.py
@@ -31,6 +31,13 @@ class TransformEditorDialog(tk.Toplevel):
         self.result = None
         self.title(f"Transform Editor for CEF Field: {cef_field}")
         self.minsize(300, 360)
+        menu_bar = tk.Menu(self)
+        file_menu = tk.Menu(menu_bar, tearoff=0)
+        file_menu.add_command(label="Save", command=self._on_save, accelerator="Ctrl+S")
+        file_menu.add_command(label="Cancel", command=self.destroy)
+        menu_bar.add_cascade(label="File", menu=file_menu)
+        self.config(menu=menu_bar)
+        self.bind_all("<Control-s>", lambda e: self._on_save())
         self.examples = examples or []
         self.logs = logs or []
         self.regex = regex

--- a/gui/user_pattern_editor.py
+++ b/gui/user_pattern_editor.py
@@ -12,6 +12,11 @@ class UserPatternEditorDialog(tk.Toplevel):
         super().__init__(parent)
         set_window_icon(self)
         self.title("User Patterns")
+        menu_bar = tk.Menu(self)
+        file_menu = tk.Menu(menu_bar, tearoff=0)
+        file_menu.add_command(label="Save", command=self._save_all)
+        menu_bar.add_cascade(label="File", menu=file_menu)
+        self.config(menu=menu_bar)
         self.patterns = [p for p in json_utils.load_all_patterns() if p.get("source") != "builtin"]
         self.selected_index = None
         self._build_ui()


### PR DESCRIPTION
## Summary
- add header action menus to CodeGenerator dialog
- add File menu with Save/Cancel to Transform Editor
- add Save entry in User Pattern Editor menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448227bdd0832b9c7a39a92a2ca11d