### PR TITLE
Fix PatternWizard underscore variable bug

### DIFF
--- a/gui/pattern_wizard.py
+++ b/gui/pattern_wizard.py
@@ -362,11 +362,11 @@ class PatternWizardDialog(tk.Toplevel):
         end = min(start + self.page_size, len(lines_info))
         page_lines = lines_info[start:end]
 
-        for _, line, _ in page_lines:
+        for _idx, line, _m in page_lines:
             self.match_text.insert(tk.END, line + "\n")
 
         matches_by_line = {}
-        for idx, (_, _, matches) in enumerate(page_lines, start=1):
+        for idx, (_lineno, _line, matches) in enumerate(page_lines, start=1):
             if matches:
                 matches_by_line[idx] = [
                     {


### PR DESCRIPTION
## Summary
- avoid using `_` variable name in `PatternWizardDialog._apply_regex`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a4b83378832b991b4a11bd2435d6