### PR TITLE
Wrap GUI OK labels with translation

### DIFF
--- a/data/translations.json
+++ b/data/translations.json
@@ -125,6 +125,7 @@
   "Failed to open wizard: {e}": "Не удалось открыть мастер: {e}",
   "Files written to {out_dir}": "Файлы записаны в {out_dir}",
   "Pattern '{name}' saved.": "Шаблон '{name}' сохранён.",
-  "Transform Editor for CEF Field: {cef_field}": "Редактор преобразований для поля CEF: {cef_field}"
+  "Transform Editor for CEF Field: {cef_field}": "Редактор преобразований для поля CEF: {cef_field}",
+  "OK": "ОК"
 }
 

--- a/gui/cef_field_dialog.py
+++ b/gui/cef_field_dialog.py
@@ -40,7 +40,7 @@ class CEFFieldDialog(tk.Toplevel):
 
         btns = ttk.Frame(self)
         btns.pack(pady=5)
-        ttk.Button(btns, text="OK", command=self._on_ok).pack(side="left", padx=5)
+        ttk.Button(btns, text=_("OK"), command=self._on_ok).pack(side="left", padx=5)
         ttk.Button(btns, text=_("Cancel"), command=self._on_cancel).pack(side="left", padx=5)
 
     def _on_ok(self):

--- a/gui/code_generator_dialog.py
+++ b/gui/code_generator_dialog.py
@@ -266,7 +266,7 @@ class CodeGeneratorDialog(tk.Toplevel):
             result["val"] = var.get()
             dlg.destroy()
 
-        ttk.Button(dlg, text="OK", command=ok).pack(pady=5)
+        ttk.Button(dlg, text=_("OK"), command=ok).pack(pady=5)
         dlg.grab_set()
         self.wait_window(dlg)
         return result["val"]


### PR DESCRIPTION
## Summary
- localize OK buttons
- add translation for 'OK'

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a4dde21c832b8b38d56be4683bfd