### PR TITLE
Localize pattern snippet labels

### DIFF
--- a/data/translations.json
+++ b/data/translations.json
@@ -125,6 +125,11 @@
   "Failed to open wizard: {e}": "Не удалось открыть мастер: {e}",
   "Files written to {out_dir}": "Файлы записаны в {out_dir}",
   "Pattern '{name}' saved.": "Шаблон '{name}' сохранён.",
-  "Transform Editor for CEF Field: {cef_field}": "Редактор преобразований для поля CEF: {cef_field}"
+  "Transform Editor for CEF Field: {cef_field}": "Редактор преобразований для поля CEF: {cef_field}",
+  "One word (non-space characters)": "Одно слово (не пробелы)",
+  "Line to end (non-greedy)": "До конца строки (лениво)",
+  "Fixed length number (3)": "Число фикс. длины (3)",
+  "Segment in []": "Сегмент в []",
+  "Segment in ()": "Сегмент в ()"
 }
 

--- a/gui/pattern_wizard.py
+++ b/gui/pattern_wizard.py
@@ -210,7 +210,7 @@ class PatternWizardDialog(tk.Toplevel):
 
         self.SNIPPET_DEFAULT = _("Insert snippet...")
         self.snippet_var = tk.StringVar(value=self.SNIPPET_DEFAULT)
-        self.snippet_map = {label: regex for label, regex in SNIPPETS}
+        self.snippet_map = {_(label): regex for label, regex in SNIPPETS}
         snippet_combo = ttk.Combobox(
             regex_frame,
             textvariable=self.snippet_var,


### PR DESCRIPTION
## Summary
- localize the pattern wizard snippet labels
- add translations for snippet labels in Russian

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a4dc67e8832b9c0c31d6ee3a5cf5