### PR TITLE
Fix translations JSON error

### DIFF
--- a/data/translations.json
+++ b/data/translations.json
@@ -144,12 +144,12 @@
   "Example": "Пример",
   "Result": "Результат",
   "Custom": "Своя настройка",
-  "Capitalized": "Каждое слово с заглавной буквы"
+  "Capitalized": "Каждое слово с заглавной буквы",
   "One word (non-space characters)": "Одно слово (без пробельных символов)",
   "Line to end (non-greedy)": "До конца строки (лениво)",
   "Fixed length number (3)": "Число фикс. длины (3)",
   "Segment in []": "Сегмент в []",
-  "Segment in ()": "Сегмент в ()"
+  "Segment in ()": "Сегмент в ()",
   "OK": "ОК"
 }
 


### PR DESCRIPTION
## Summary
- fix JSON syntax errors in `translations.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a8e92934832b9878e78adfb163b3