### PR TITLE
Reload main window after language change

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -457,6 +457,14 @@ class AppWindow(tk.Frame):
     def _set_language(self, lang: str):
         self.language_var.set('Русский' if lang == 'ru' else 'English')
         set_language(lang)
+        # reload main window to apply translations
+        self.master.after(0, self._restart_main_window)
+
+    def _restart_main_window(self):
+        """Destroy current root and recreate the main window."""
+        from main import main as start_app
+        self.master.destroy()
+        start_app()
 
     def refresh_translations(self):
         self.cmd_menu.entryconfigure(0, label=_("Load Log"))


### PR DESCRIPTION
## Summary
- reload the main Tk window when changing language so translations apply immediately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ac861780832b91ae2be742e9ad40