### PR TITLE
Fix language menu refresh error

### DIFF
--- a/gui/app_window.py
+++ b/gui/app_window.py
@@ -77,7 +77,7 @@ class AppWindow(tk.Frame):
         self.pattern_panel.grid_propagate(False)
         self.pattern_panel.cef_fields = self.cef_fields
 
-        menubar = tk.Menu(self.master)
+        menubar = tk.Menu(self.master, tearoff=0)
         self.cmd_menu = tk.Menu(menubar, tearoff=0)
         self.cmd_menu.add_command(label=_("Load Log"), command=self.load_log_file, accelerator="Ctrl+O")
         self.cmd_menu.add_command(label=_("Save Patterns"), command=self.save_current_patterns, accelerator="Ctrl+S")


### PR DESCRIPTION
## Summary
- fix error when switching languages by disabling `Menu` tearoff

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844afc44544832b8cb113ecdecd89f9