### PR TITLE
Fix regex escapes in code generator

### DIFF
--- a/utils/code_generator.py
+++ b/utils/code_generator.py
@@ -156,7 +156,7 @@ def _reorder_tokens(value: str, regex: str, order: List[int]) -> str:
             tokens.append(tail)
     else:
         span = value[m.start():m.end()]
-        tokens = [t for t in re.split(r"([a-zA-Z]+|\d+|\W)", span) if t]
+        tokens = [t for t in re.split(r"([a-zA-Z]+|\\d+|\\W)", span) if t]
     return "".join(tokens[i] for i in order if i < len(tokens))
 
 


### PR DESCRIPTION
## Summary
- escape regex tokens inside the converter code template to avoid a SyntaxWarning

## Testing
- `python -Wall -m py_compile utils/code_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b30c4af4832bbad3e4390017f99f